### PR TITLE
[Hotfix] Home API NPE 수정 및 철학자 이미지 presigned URL 연동

### DIFF
--- a/src/main/java/com/swyp/app/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/com/swyp/app/domain/battle/converter/BattleConverter.java
@@ -126,6 +126,7 @@ public class BattleConverter {
     }
 
     private List<BattleOptionResponse> toOptionResponses(List<BattleOption> options) {
+        if (options == null) return List.of();
         return options.stream()
                 .map(o -> {
                     List<Tag> optionTags = optionTagRepository.findByBattleOption(o).stream()
@@ -141,12 +142,14 @@ public class BattleConverter {
     }
 
     private List<TodayOptionResponse> toTodayOptionResponses(List<BattleOption> options) {
+        if (options == null) return List.of();
         return options.stream().map(o -> new TodayOptionResponse(
                 o.getId(), o.getLabel(), o.getTitle(), o.getRepresentative(), o.getStance(), o.getImageUrl()
         )).toList();
     }
 
     private List<BattleTagResponse> toTagResponses(List<Tag> tags, TagType targetType) {
+        if (tags == null) return List.of();
         return tags.stream()
                 .filter(t -> targetType == null || t.getType() == targetType)
                 .map(t -> new BattleTagResponse(t.getId(), t.getName(), t.getType()))

--- a/src/main/java/com/swyp/app/domain/home/service/HomeService.java
+++ b/src/main/java/com/swyp/app/domain/home/service/HomeService.java
@@ -10,6 +10,8 @@ import com.swyp.app.domain.battle.service.BattleService;
 import com.swyp.app.domain.home.dto.response.*;
 import com.swyp.app.domain.notification.enums.NotificationCategory;
 import com.swyp.app.domain.notification.service.NotificationService;
+import com.swyp.app.domain.user.entity.PhilosopherType;
+import com.swyp.app.global.infra.s3.service.S3PresignedUrlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ public class HomeService {
 
     private final BattleService battleService;
     private final NotificationService notificationService;
+    private final S3PresignedUrlService s3PresignedUrlService;
 
     public HomeResponse getHome() {
         boolean newNotice = notificationService.hasNewBroadcast(NotificationCategory.NOTICE);
@@ -89,7 +92,7 @@ public class HomeService {
     }
 
     private HomeTodayVoteResponse toTodayVote(TodayBattleResponse b) {
-        List<HomeTodayVoteOptionResponse> options = b.options().stream()
+        List<HomeTodayVoteOptionResponse> options = Optional.ofNullable(b.options()).orElse(List.of()).stream()
                 .map(o -> new HomeTodayVoteOptionResponse(o.label(), o.title()))
                 .toList();
         return new HomeTodayVoteResponse(
@@ -104,8 +107,8 @@ public class HomeService {
         List<String> philosophers = findPhilosopherNames(b.tags());
         String philoA = philosophers.size() > 0 ? philosophers.get(0) : null;
         String philoB = philosophers.size() > 1 ? philosophers.get(1) : null;
-        String imageA = findOptionImageUrl(b.options(), BattleOptionLabel.A);
-        String imageB = findOptionImageUrl(b.options(), BattleOptionLabel.B);
+        String imageA = findRepresentativeImageUrl(b.options(), BattleOptionLabel.A);
+        String imageB = findRepresentativeImageUrl(b.options(), BattleOptionLabel.B);
         return new HomeNewBattleResponse(
                 b.battleId(), b.thumbnailUrl(),
                 b.title(), b.summary(),
@@ -129,11 +132,15 @@ public class HomeService {
                 .toList();
     }
 
-    private String findOptionImageUrl(List<TodayOptionResponse> options, BattleOptionLabel label) {
+    private String findRepresentativeImageUrl(List<TodayOptionResponse> options, BattleOptionLabel label) {
         return Optional.ofNullable(options).orElse(List.of()).stream()
                 .filter(o -> o.label() == label)
-                .map(TodayOptionResponse::imageUrl)
-                .findFirst().orElse(null);
+                .map(TodayOptionResponse::representative)
+                .findFirst()
+                .map(PhilosopherType::fromLabel)
+                .map(PhilosopherType::getImageKey)
+                .map(s3PresignedUrlService::generatePresignedUrl)
+                .orElse(null);
     }
 
     @SafeVarargs

--- a/src/main/java/com/swyp/app/domain/user/entity/PhilosopherType.java
+++ b/src/main/java/com/swyp/app/domain/user/entity/PhilosopherType.java
@@ -45,7 +45,25 @@ public enum PhilosopherType {
     BUDDHA("붓다", "내면형", "외부의 소음에서 벗어나 마음속 깊은 평화와 고요를 찾는 수행자",
             "LAOZI", "ARISTOTLE",
             35, 55, 42, 48, 96, 62,
-            "images/philosophers/buddha.png");
+            "images/philosophers/buddha.png"),
+    AQUINAS("토마스 아퀴나스", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/aquinas.png"),
+    CAMUS("카뮈", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/camus.png"),
+    CHOE_HANGI("최한기", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/choe_hangi.png"),
+    DESCARTES("데카르트", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/descartes.png"),
+    EPICURUS("에피쿠로스", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/epicurus.png"),
+    FROMM("에리히 프롬", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/fromm.png"),
+    HOBBES("홉스", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/hobbes.png"),
+    HUME("흄", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/hume.png"),
+    JEONG_YAKYONG("정약용", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/jeong_yakyong.png"),
+    JUNG("융", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/jung.png"),
+    LEIBNIZ("라이프니츠", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/leibniz.png"),
+    MENCIUS("맹자", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/mencius.png"),
+    MILL("존 스튜어트 밀", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/mill.png"),
+    RAWLS("롤스", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/rawls.png"),
+    SCHOPENHAUER("쇼펜하우어", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/schopenhauer.png"),
+    XUNZI("순자", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/xunzi.png"),
+    YI_HWANG("이황", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/yi_hwang.png"),
+    YI_I("이이", null, null, null, null, 0, 0, 0, 0, 0, 0, "images/philosophers/yi_i.png");
 
     private final String label;
     private final String typeName;
@@ -80,11 +98,11 @@ public enum PhilosopherType {
     }
 
     public PhilosopherType getBestMatch() {
-        return valueOf(bestMatchName);
+        return bestMatchName != null ? valueOf(bestMatchName) : null;
     }
 
     public PhilosopherType getWorstMatch() {
-        return valueOf(worstMatchName);
+        return worstMatchName != null ? valueOf(worstMatchName) : null;
     }
 
     public static PhilosopherType fromLabel(String label) {


### PR DESCRIPTION
## Summary
- Home API (`GET /api/v1/home`) 500 에러 수정: `findOptionImageUrl`에서 null imageUrl로 인한 NPE 해결
- 신규 배틀 섹션 철학자 이미지를 `battle_options.representative` 한글명 → `PhilosopherType` enum 매칭 → S3 presigned URL로 제공하도록 변경
- 배틀 전용 철학자 17명 PhilosopherType enum에 추가 (더미값)
- Home API 전체 흐름 null safety 강화 (BattleConverter, HomeService)

## Changes
- `HomeService`: `findOptionImageUrl` → `findRepresentativeImageUrl` (representative 기반 이미지 조회)
- `PhilosopherType`: 17개 신규 철학자 enum 추가, `getBestMatch`/`getWorstMatch` null guard
- `BattleConverter`: `toOptionResponses`, `toTodayOptionResponses`, `toTagResponses` null guard

## Test plan
- [ ] Home API (`GET /api/v1/home`) 정상 응답 확인
- [ ] 신규 배틀 섹션 철학자 이미지 URL이 S3 presigned URL로 반환되는지 확인
- [ ] options/tags가 null인 배틀 데이터에서 NPE 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)