### PR TITLE
[Hotfix] HomeService stream NPE 수정

### DIFF
--- a/src/main/java/com/swyp/app/domain/home/service/HomeService.java
+++ b/src/main/java/com/swyp/app/domain/home/service/HomeService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -122,6 +123,7 @@ public class HomeService {
         return Optional.ofNullable(options).orElse(List.of()).stream()
                 .filter(o -> o.label() == label)
                 .map(TodayOptionResponse::title)
+                .filter(Objects::nonNull)
                 .findFirst().orElse(null);
     }
 
@@ -136,6 +138,7 @@ public class HomeService {
         return Optional.ofNullable(options).orElse(List.of()).stream()
                 .filter(o -> o.label() == label)
                 .map(TodayOptionResponse::representative)
+                .filter(Objects::nonNull)
                 .findFirst()
                 .map(PhilosopherType::fromLabel)
                 .map(PhilosopherType::getImageKey)


### PR DESCRIPTION
## Summary
- `findRepresentativeImageUrl`, `findOptionTitle`에서 `representative`/`title`이 null일 때 `findFirst()` → `Optional.of(null)` NPE 발생하는 문제 수정
- `.filter(Objects::nonNull)`을 `findFirst()` 앞에 추가

## Test plan
- [ ] Home API (`GET /api/v1/home`) 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)