### PR TITLE
#86 [Fix] characterType null 체크 추가 - 미설정 유저 NPE 수정

### DIFF
--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
@@ -61,8 +61,9 @@ public class PerspectiveCommentService {
         perspective.incrementCommentCount();
 
         UserSummary userSummary = userQueryService.findSummaryById(userId);
-        String characterImageUrl = s3PresignedUrlService.generatePresignedUrl(
-                CharacterType.from(userSummary.characterType()).getImageKey());
+        String characterImageUrl = userSummary.characterType() != null
+                ? s3PresignedUrlService.generatePresignedUrl(CharacterType.from(userSummary.characterType()).getImageKey())
+                : null;
         Long postVoteOptionId = voteService.findPostVoteOptionId(perspective.getBattle().getId(), userId);
         String stance = null;
         if (postVoteOptionId != null) {
@@ -96,8 +97,9 @@ public class PerspectiveCommentService {
                 .filter(c -> !c.isHidden())
                 .map(c -> {
                     UserSummary user = userQueryService.findSummaryById(c.getUser().getId());
-                    String characterImageUrl = s3PresignedUrlService.generatePresignedUrl(
-                            CharacterType.from(user.characterType()).getImageKey());
+                    String characterImageUrl = user.characterType() != null
+                            ? s3PresignedUrlService.generatePresignedUrl(CharacterType.from(user.characterType()).getImageKey())
+                            : null;
                     Long postVoteOptionId = voteService.findPostVoteOptionId(battleId, c.getUser().getId());
                     String stance = null;
                     if (postVoteOptionId != null) {

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
@@ -54,8 +54,9 @@ public class PerspectiveService {
             throw new CustomException(ErrorCode.PERSPECTIVE_NOT_FOUND);
         }
         UserSummary user = userQueryService.findSummaryById(perspective.getUser().getId());
-        String characterImageUrl = s3PresignedUrlService.generatePresignedUrl(
-                CharacterType.from(user.characterType()).getImageKey());
+        String characterImageUrl = user.characterType() != null
+                ? s3PresignedUrlService.generatePresignedUrl(CharacterType.from(user.characterType()).getImageKey())
+                : null;
         BattleOption option = perspective.getOption();
         boolean isLiked = perspectiveLikeRepository.existsByPerspectiveAndUserId(perspective, userId);
         return new PerspectiveDetailResponse(
@@ -123,8 +124,9 @@ public class PerspectiveService {
         List<PerspectiveListResponse.Item> items = perspectives.stream()
                 .map(p -> {
                     UserSummary user = userQueryService.findSummaryById(p.getUser().getId());
-                    String characterImageUrl = s3PresignedUrlService.generatePresignedUrl(
-                            CharacterType.from(user.characterType()).getImageKey());
+                    String characterImageUrl = user.characterType() != null
+                            ? s3PresignedUrlService.generatePresignedUrl(CharacterType.from(user.characterType()).getImageKey())
+                            : null;
                     BattleOption option = p.getOption();
                     boolean isLiked = perspectiveLikeRepository.existsByPerspectiveAndUserId(p, userId);
                     return new PerspectiveListResponse.Item(
@@ -171,8 +173,9 @@ public class PerspectiveService {
                 .orElseThrow(() -> new CustomException(ErrorCode.PERSPECTIVE_NOT_FOUND));
 
         UserSummary user = userQueryService.findSummaryById(userId);
-        String characterImageUrl = s3PresignedUrlService.generatePresignedUrl(
-                CharacterType.from(user.characterType()).getImageKey());
+        String characterImageUrl = user.characterType() != null
+                ? s3PresignedUrlService.generatePresignedUrl(CharacterType.from(user.characterType()).getImageKey())
+                : null;
         BattleOption option = perspective.getOption();
         boolean isLiked = perspectiveLikeRepository.existsByPerspectiveAndUserId(perspective, userId);
 

--- a/src/main/java/com/swyp/picke/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/UserService.java
@@ -77,7 +77,8 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         UserProfile profile = findUserProfile(user.getId());
-        return new UserSummary(user.getUserTag(), profile.getNickname(), profile.getCharacterType().name());
+        String characterType = profile.getCharacterType() != null ? profile.getCharacterType().name() : null;
+        return new UserSummary(user.getUserTag(), profile.getNickname(), characterType);
     }
 
     public User findCurrentUser() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- Ex) - #이슈번호 -->
<!-- 연관된 이슈 번호를 링크 형태로 작성하세요 -->
- #86 

## 📝 작업 내용
<!-- 이번 PR/이슈에서 실제 수행한 작업 내용을 작성하세요 -->
- UserService: getCharacterType() NPE 방지, null이면 null 반환
- PerspectiveService: characterImageUrl 생성 시 characterType null 체크 (3군데)
- PerspectiveCommentService: characterImageUrl 생성 시 characterType null 체크 (2군데)

  ## 📝 작업 내용
                                                                                                                                                                                                                                    
  ### 🐛 Fix                                                
  | 내용 | 파일 |
  |------|------|
  | `getCharacterType()` null 체크 추가 - null이면 null 반환 | `UserService.java` |
  | `characterImageUrl` 생성 시 `characterType` null 체크 (3군데) | `PerspectiveService.java` |
  | `characterImageUrl` 생성 시 `characterType` null 체크 (2군데) | `PerspectiveCommentService.java` |

  ## 📌 공유 사항
  > 1. 회원가입(최초 로그인) 시 `character_type`은 NULL로 시작하며, 사용자가 프로필에서 캐릭터를 선택해야 설정됩니다.
  > 2. 기존 코드는 `character_type`이 항상 non-null임을 가정하고 있어, 캐릭터 미설정 유저가 관점/댓글 API 호출 시 NPE가 발생했습니다.
  > 3. `MypageService` 기존 처리 방식과 동일하게, null이면 null 그대로 응답에 내려보내도록 수정했습니다.

  ## ✅ 체크리스트
  - [ x ] Reviewer에 팀원들을 선택했나요?
  - [ x ] Assignees에 본인을 선택했나요?
  - [ x ] 컨벤션에 맞는 Type을 선택했나요?
  - [ x ] Development에 이슈를 연동했나요?
  - [ x ] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [ x ] 컨벤션을 지키고 있나요?
  - [ x ] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [ x ] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷
  > EC2 서버 로그에서 확인된 NPE:
  > `Cannot invoke "CharacterType.name()" because the return value of "UserProfile.getCharacterType()" is null`
  > `at UserService.findSummaryById(UserService.java:80)`

  ## 💬 리뷰 요구사항
  > 1. 현재 캐릭터 미설정 유저에 대해 `characterType`, `characterImageUrl` 모두 null로 내려보내는 중