### PR TITLE
[Feat] 콘텐츠 활동 내역 API 캐릭터 이미지 URL 추가

### DIFF
--- a/src/main/java/com/swyp/picke/domain/user/dto/response/ContentActivityListResponse.java
+++ b/src/main/java/com/swyp/picke/domain/user/dto/response/ContentActivityListResponse.java
@@ -30,7 +30,8 @@ public record ContentActivityListResponse(
     public record AuthorInfo(
             String userTag,
             String nickname,
-            CharacterType characterType
+            CharacterType characterType,
+            String characterImageUrl
     ) {
     }
 }

--- a/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
@@ -187,6 +187,9 @@ public class MypageService {
         List<PerspectiveComment> comments = perspectiveQueryService.findUserComments(user.getId(), pageOffset, pageSize);
         long totalCount = perspectiveQueryService.countUserComments(user.getId());
 
+        UserProfile profile = userService.findUserProfile(user.getId());
+        String myCharacterImageUrl = resolveCharacterImageUrl(profile.getCharacterType());
+
         List<Perspective> perspectives = comments.stream().map(PerspectiveComment::getPerspective).toList();
         Map<Long, Battle> battleMap = loadBattles(perspectives);
         Map<Long, BattleOption> optionMap = loadOptions(perspectives);
@@ -196,7 +199,7 @@ public class MypageService {
                     Perspective p = comment.getPerspective();
                     return toActivityItem(comment.getId().toString(), ActivityType.COMMENT, p,
                             battleMap.get(p.getBattle().getId()), optionMap.get(p.getOption().getId()),
-                            comment.getContent(), comment.getCreatedAt());
+                            comment.getContent(), comment.getCreatedAt(), myCharacterImageUrl);
                 })
                 .toList();
 
@@ -216,9 +219,11 @@ public class MypageService {
         List<ContentActivityListResponse.ContentActivityItem> items = likes.stream()
                 .map(like -> {
                     Perspective p = like.getPerspective();
+                    UserSummary perspectiveAuthor = userService.findSummaryById(p.getUser().getId());
+                    String authorCharacterImageUrl = resolveCharacterImageUrl(perspectiveAuthor.characterType());
                     return toActivityItem(like.getId().toString(), ActivityType.LIKE, p,
                             battleMap.get(p.getBattle().getId()), optionMap.get(p.getOption().getId()),
-                            p.getContent(), like.getCreatedAt());
+                            p.getContent(), like.getCreatedAt(), authorCharacterImageUrl);
                 })
                 .toList();
 
@@ -229,13 +234,15 @@ public class MypageService {
 
     private ContentActivityListResponse.ContentActivityItem toActivityItem(
             String activityId, ActivityType activityType, Perspective perspective,
-            Battle battle, BattleOption option, String content, LocalDateTime createdAt) {
+            Battle battle, BattleOption option, String content, LocalDateTime createdAt,
+            String characterImageUrl) {
 
         UserSummary author = userService.findSummaryById(perspective.getUser().getId());
         ContentActivityListResponse.AuthorInfo authorInfo = new ContentActivityListResponse.AuthorInfo(
                 author.userTag(),
                 author.nickname(),
-                author.characterType() != null ? CharacterType.from(author.characterType()) : null
+                author.characterType() != null ? CharacterType.from(author.characterType()) : null,
+                characterImageUrl
         );
 
         VoteSide voteSide = option != null
@@ -340,5 +347,13 @@ public class MypageService {
     private String resolveCharacterImageUrl(CharacterType characterType) {
         String imageKey = CharacterType.resolveImageKey(characterType);
         return imageKey != null ? s3PresignedUrlService.generatePresignedUrl(imageKey) : null;
+    }
+
+    private String resolveCharacterImageUrl(String characterType) {
+        if (characterType == null || characterType.isBlank()) {
+            return null;
+        }
+        String imageKey = CharacterType.resolveImageKey(characterType);
+        return s3PresignedUrlService.generatePresignedUrl(imageKey);
     }
 }


### PR DESCRIPTION
## Summary
- 마이페이지 콘텐츠 활동 내역 API 응답에 캐릭터 이미지 URL 추가
- 댓글: 현재 사용자(나)의 캐릭터 이미지 URL 반환
- 좋아요: 좋아요한 글 작성자의 캐릭터 이미지 URL 반환

## Changes
- `ContentActivityListResponse.AuthorInfo`에 `characterImageUrl` 필드 추가
- `MypageService.buildCommentActivities`: 현재 사용자 프로필에서 캐릭터 URL 조회
- `MypageService.buildLikeActivities`: 글 작성자의 캐릭터 URL 조회
- `MypageService.resolveCharacterImageUrl(String)` 오버로드 추가

## Test plan
- [ ] 댓글 활동 조회 시 `author.characterImageUrl`에 현재 사용자의 캐릭터 이미지 URL 반환 확인
- [ ] 좋아요 활동 조회 시 `author.characterImageUrl`에 글 작성자의 캐릭터 이미지 URL 반환 확인
- [ ] 캐릭터 타입이 null인 경우 `characterImageUrl`이 null로 반환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)