### PR TITLE
#128 [Feat] 철학자 유형 계산 옵션 기반 개선, 투표 totalCount 추가, 홈 title/summary 수정

### DIFF
--- a/src/main/java/com/swyp/picke/domain/battle/repository/BattleOptionTagRepository.java
+++ b/src/main/java/com/swyp/picke/domain/battle/repository/BattleOptionTagRepository.java
@@ -14,4 +14,7 @@ public interface BattleOptionTagRepository extends JpaRepository<BattleOptionTag
 
     @Query("SELECT bot FROM BattleOptionTag bot JOIN FETCH bot.tag WHERE bot.battleOption.battle = :battle")
     List<BattleOptionTag> findByBattleWithTags(@Param("battle") Battle battle);
+
+    @Query("SELECT bot FROM BattleOptionTag bot JOIN FETCH bot.tag WHERE bot.battleOption.id IN :optionIds")
+    List<BattleOptionTag> findByBattleOptionIdIn(@Param("optionIds") List<Long> optionIds);
 }

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleQueryService.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleQueryService.java
@@ -2,8 +2,10 @@ package com.swyp.picke.domain.battle.service;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
+import com.swyp.picke.domain.battle.entity.BattleOptionTag;
 import com.swyp.picke.domain.battle.entity.BattleTag;
 import com.swyp.picke.domain.battle.repository.BattleOptionRepository;
+import com.swyp.picke.domain.battle.repository.BattleOptionTagRepository;
 import com.swyp.picke.domain.battle.repository.BattleRepository;
 import com.swyp.picke.domain.battle.repository.BattleTagRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class BattleQueryService {
     private final BattleRepository battleRepository;
     private final BattleOptionRepository battleOptionRepository;
     private final BattleTagRepository battleTagRepository;
+    private final BattleOptionTagRepository battleOptionTagRepository;
 
     public Map<Long, Battle> findBattlesByIds(List<Long> battleIds) {
         return battleRepository.findAllById(battleIds).stream()
@@ -74,15 +77,15 @@ public class BattleQueryService {
                 ));
     }
 
-    public Optional<String> getTopPhilosopherTagName(List<Long> battleIds) {
-        if (battleIds.isEmpty()) return Optional.empty();
+    public Optional<String> getTopPhilosopherTagNameFromOptions(List<Long> optionIds) {
+        if (optionIds.isEmpty()) return Optional.empty();
 
-        List<BattleTag> battleTags = battleTagRepository.findByBattleIdIn(battleIds);
+        List<BattleOptionTag> optionTags = battleOptionTagRepository.findByBattleOptionIdIn(optionIds);
 
-        return battleTags.stream()
-                .filter(bt -> bt.getTag().getType() == TagType.PHILOSOPHER)
+        return optionTags.stream()
+                .filter(bot -> bot.getTag().getType() == TagType.PHILOSOPHER)
                 .collect(Collectors.groupingBy(
-                        bt -> bt.getTag().getName(),
+                        bot -> bot.getTag().getName(),
                         Collectors.counting()
                 ))
                 .entrySet().stream()

--- a/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
@@ -20,6 +20,8 @@ import com.swyp.picke.domain.user.entity.UserSettings;
 import com.swyp.picke.domain.user.enums.VoteSide;
 import com.swyp.picke.domain.vote.entity.Vote;
 import com.swyp.picke.domain.vote.service.VoteQueryService;
+import com.swyp.picke.global.common.exception.CustomException;
+import com.swyp.picke.global.common.exception.ErrorCode;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -305,14 +307,15 @@ public class MypageService {
             return null;
         }
 
-        List<Long> battleIds = voteQueryService.findFirstNBattleIds(userId, PHILOSOPHER_CALC_THRESHOLD);
-        return battleQueryService.getTopPhilosopherTagName(battleIds)
+        List<Long> optionIds = voteQueryService.findFirstNVotedOptionIds(userId, PHILOSOPHER_CALC_THRESHOLD);
+
+        return battleQueryService.getTopPhilosopherTagNameFromOptions(optionIds)
                 .map(PhilosopherType::fromLabel)
                 .map(type -> {
                     profile.updatePhilosopherType(type);
                     return type;
                 })
-                .orElse(null);
+                .orElseThrow(() -> new CustomException(ErrorCode.PHILOSOPHER_CALC_FAILED));
     }
 
     private RecapResponse.PhilosopherCard toPhilosopherCard(PhilosopherType type) {

--- a/src/main/java/com/swyp/picke/domain/user/service/UserService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/UserService.java
@@ -74,8 +74,8 @@ public class UserService {
             return PhilosopherType.SOCRATES;
         }
 
-        List<Long> battleIds = voteQueryService.findFirstNBattleIds(userId, PHILOSOPHER_CALC_THRESHOLD);
-        return battleQueryService.getTopPhilosopherTagName(battleIds)
+        List<Long> optionIds = voteQueryService.findFirstNBattleIds(userId, PHILOSOPHER_CALC_THRESHOLD);
+        return battleQueryService.getTopPhilosopherTagNameFromOptions(optionIds)
                 .map(PhilosopherType::fromLabel)
                 .map(type -> {
                     profile.updatePhilosopherType(type);

--- a/src/main/java/com/swyp/picke/domain/vote/dto/response/PollVoteResponse.java
+++ b/src/main/java/com/swyp/picke/domain/vote/dto/response/PollVoteResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record PollVoteResponse(
         Long battleId,
         Long selectedOptionId,
+        long totalCount,
         List<OptionStat> stats
 ) {
     public record OptionStat(Long optionId, String label, String title, long voteCount, double ratio) {}

--- a/src/main/java/com/swyp/picke/domain/vote/dto/response/QuizVoteResponse.java
+++ b/src/main/java/com/swyp/picke/domain/vote/dto/response/QuizVoteResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record QuizVoteResponse(
         Long battleId,
         Long selectedOptionId,
+        long totalCount,
         List<OptionStat> stats
 ) {
     public record OptionStat(Long optionId, String label, String title, Boolean isCorrect, long voteCount, double ratio) {}

--- a/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteServiceImpl.java
@@ -33,17 +33,30 @@ public class QuizVoteServiceImpl implements QuizVoteService {
     @Transactional
     public QuizVoteResponse submitQuiz(Long battleId, Long userId, QuizVoteRequest request) {
         QuizVote v = saveOrUpdate(battleId, userId, request.optionId());
-        return new QuizVoteResponse(battleId, v.getSelectedOption().getId(), calcStats(v.getBattle()));
+        long totalCount = quizVoteRepository.countByBattle(v.getBattle());
+
+        return new QuizVoteResponse(
+                battleId,
+                v.getSelectedOption().getId(),
+                totalCount,
+                calcStats(v.getBattle(), totalCount)
+        );
     }
 
     @Override
     @Transactional
     public PollVoteResponse submitPoll(Long battleId, Long userId, QuizVoteRequest request) {
         QuizVote v = saveOrUpdate(battleId, userId, request.optionId());
-        return new PollVoteResponse(battleId, v.getSelectedOption().getId(),
-                calcStats(v.getBattle()).stream()
+        long totalCount = quizVoteRepository.countByBattle(v.getBattle());
+
+        return new PollVoteResponse(
+                battleId,
+                v.getSelectedOption().getId(),
+                totalCount,
+                calcStats(v.getBattle(), totalCount).stream()
                         .map(s -> new PollVoteResponse.OptionStat(s.optionId(), s.label(), s.title(), s.voteCount(), s.ratio()))
-                        .toList());
+                        .toList()
+        );
     }
 
     @Override
@@ -53,11 +66,15 @@ public class QuizVoteServiceImpl implements QuizVoteService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return quizVoteRepository.findByBattleAndUser(battle, user)
-                .map(v -> new QuizVoteResponse(
-                        battleId,
-                        v.getSelectedOption().getId(),
-                        calcStats(battle)
-                ))
+                .map(v -> {
+                    long totalCount = quizVoteRepository.countByBattle(battle);
+                    return new QuizVoteResponse(
+                            battleId,
+                            v.getSelectedOption().getId(),
+                            totalCount,
+                            calcStats(battle, totalCount)
+                    );
+                })
                 .orElse(null);
     }
 
@@ -68,13 +85,17 @@ public class QuizVoteServiceImpl implements QuizVoteService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return quizVoteRepository.findByBattleAndUser(battle, user)
-                .map(v -> new PollVoteResponse(
-                        battleId,
-                        v.getSelectedOption().getId(),
-                        calcStats(battle).stream()
-                                .map(s -> new PollVoteResponse.OptionStat(s.optionId(), s.label(), s.title(), s.voteCount(), s.ratio()))
-                                .toList()
-                ))
+                .map(v -> {
+                    long totalCount = quizVoteRepository.countByBattle(battle);
+                    return new PollVoteResponse(
+                            battleId,
+                            v.getSelectedOption().getId(),
+                            totalCount,
+                            calcStats(battle, totalCount).stream()
+                                    .map(s -> new PollVoteResponse.OptionStat(s.optionId(), s.label(), s.title(), s.voteCount(), s.ratio()))
+                                    .toList()
+                    );
+                })
                 .orElse(null);
     }
 
@@ -94,16 +115,15 @@ public class QuizVoteServiceImpl implements QuizVoteService {
                 });
     }
 
-    private List<QuizVoteResponse.OptionStat> calcStats(Battle battle) {
-        long total = quizVoteRepository.countByBattle(battle);
+    private List<QuizVoteResponse.OptionStat> calcStats(Battle battle, long totalCount) {
         return battleOptionRepository.findByBattle(battle).stream().map(o -> {
             long count = quizVoteRepository.countByBattleAndSelectedOption(battle, o);
-            double ratio = total == 0 ? 0.0 : Math.round((double) count / total * 1000) / 10.0;
+            double ratio = totalCount == 0 ? 0.0 : Math.round((double) count / totalCount * 1000) / 10.0;
             return new QuizVoteResponse.OptionStat(
                     o.getId(),
                     o.getLabel().name(),
                     o.getTitle(),
-                    o.getIsCorrect(), // 이 부분!
+                    o.getIsCorrect(),
                     count,
                     ratio
             );

--- a/src/main/java/com/swyp/picke/domain/vote/service/VoteQueryService.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/VoteQueryService.java
@@ -74,4 +74,16 @@ public class VoteQueryService {
                 .distinct()
                 .toList();
     }
+
+    public List<Long> findFirstNVotedOptionIds(Long userId, int n) {
+        return voteRepository.findByUserIdOrderByCreatedAtAsc(userId, PageRequest.of(0, n)).stream()
+                .map(v -> {
+                    if (v.getPostVoteOption() != null) return v.getPostVoteOption().getId();
+                    if (v.getPreVoteOption() != null) return v.getPreVoteOption().getId();
+                    return null;
+                })
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+    }
 }

--- a/src/main/java/com/swyp/picke/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/picke/global/common/exception/ErrorCode.java
@@ -98,7 +98,10 @@ public enum ErrorCode {
     // Reward
     REWARD_INVALID_USER(HttpStatus.NOT_FOUND, "REWARD_404", "해당 유저를 찾을 수 없습니다."),
     REWARD_INVALID_TYPE(HttpStatus.BAD_REQUEST, "REWARD_400", "지원하지 않는 보상 아이템 타입입니다."),
-    REWARD_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "REWARD_401", "AdMob 서명 검증에 실패하였습니다.");
+    REWARD_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "REWARD_401", "AdMob 서명 검증에 실패하였습니다."),
+
+    // MyPage
+    PHILOSOPHER_CALC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_500_PHIL", "철학자 유형을 계산할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- Ex) - #이슈번호 -->
<!-- 연관된 이슈 번호를 링크 형태로 작성하세요 -->
- #128 

## 📌 공유 사항
1. 철학자 유형 계산 시 유저가 실제 선택한 옵션의 `PHILOSOPHER` 태그 기준으로 변경되었습니다.
2. `MypageService.resolvePhilosopherType`은 태그 미존재 시 `PHILOSOPHER_CALC_FAILED` 예외를 던집니다.
3. `UserService.getPhilosopherType`은 태그 미존재 시 `SOCRATES`로 폴백합니다.
4. `QuizVoteResponse`, `PollVoteResponse`에 `totalCount` 추가로 API 스펙이 변경됩니다.
5. 홈 화면 배틀 카드의 `title`에 `summary` 내용이 노출되는 문제를 수정하였습니다. `title`과 `summary` 모두 필요하며 위치를 올바르게 변경하였고, `summary` 더미데이터를 임의로 추가하였습니다.

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택했나요?
- [X] Assignees에 본인을 선택했나요?
- [X] 컨벤션에 맞는 Type을 선택했나요?
- [X] Development에 이슈를 연동했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?

## 💬 리뷰 요구사항
1. `MypageService`와 `UserService`의 폴백 전략 불일치(예외 vs SOCRATES) — 통일 여부 논의 부탁드립니다.
2. `totalCount` 추가로 인한 클라이언트 API 스펙 변경 공유가 필요합니다.

---

## 📸 스크린샷
<!-- Swagger, Postman, JUnit 테스트 화면 첨부 -->
<!-- 기능 동작 화면이나 테스트 결과 캡처를 첨부하면 좋습니다 -->
### (`POST`) 투표 생성 총 참여자 수 필드 추가
### `/api/v1/battles/{battleId}/poll-vote`
<img width="1275" height="405" alt="`(POST)` 투표 생성 총 참여자 수 필드 추가" src="https://github.com/user-attachments/assets/36c97790-9142-4662-8de0-68be1c89a1c2" />

### (`POST`) 퀴즈 생성 총 참여자 수 필드 추가
### `/api/v1/battles/{battleId}q-vote`
<img width="689" height="438" alt="(POST) 퀴즈 생성 총 참여자 수 필드 추가" src="https://github.com/user-attachments/assets/802e1092-764b-47ae-b4ac-ebaa9b16b78f" />

### (`GET`) 투표 생성 총 참여자 수 필드 추가
### ``
<img width="687" height="411" alt="(GET) 투표 생성 총 참여자 수 필드 추가" src="https://github.com/user-attachments/assets/0d586068-b290-4f27-8ece-8f8617e3c308" />

### (`GET`) 퀴즈 생성 총 참여자 수 필드 추가
### ``
<img width="682" height="432" alt="(GET) 퀴즈 생성 총 참여자 수 필드 추가" src="https://github.com/user-attachments/assets/6f69658c-eef5-40f1-a560-4d3663a713d8" />

### 홈 `API` - title, summary 포함 완료 (더미데이터 삽입)
### ``
<img width="1273" height="449" alt="홈 API title, summary 포함 완료" src="https://github.com/user-attachments/assets/6463c420-91d3-4b1f-9824-cc7016e6000c" />

### 마이페이지 `API` - 나의 철학자 유형 로직 수정 완료 (배틀 태그 `ID` → 배틀 옵션 태그 `ID`)
### ``
<img width="1275" height="445" alt="마이페이지 API 나의 철학자 유형 로직 수정 완료" src="https://github.com/user-attachments/assets/b3c12ada-f552-4444-8cd4-0f4f97cbcfea" />

---

## 📝 작업 내용

### ✨ Feat
| 내용 | 파일 |
|------|------|
| 옵션 `ID` 기반 `BattleOptionTag` 조회 쿼리 추가 | `BattleOptionTagRepository.java` |
| 옵션 `ID` 기반 철학자 태그 집계 메서드 추가 | `BattleQueryService.java` |
| 유저 투표 옵션 `ID` 조회 메서드 추가 | `VoteQueryService.java` |
| 철학자 유형 계산 옵션 기반 교체, 미계산 시 예외 처리 | `MypageService.java` |
| 철학자 유형 계산 옵션 기반 교체 | `UserService.java` |
| `totalCount` 필드 추가 | `QuizVoteResponse.java`<br>`PollVoteResponse.java` |
| `totalCount` 계산 및 응답 반영 | `QuizVoteServiceImpl.java` |
| `PHILOSOPHER_CALC_FAILED` 에러코드 추가 | `ErrorCode.java` |
| 홈 화면 `title`/`summary` 필드 위치 수정 및 더미데이터 추가 | 홈 관련 파일 |