### PR TITLE
#130 [Feat] 퀴즈/투표 voteCount 캐싱 및 관리자 삭제 API 분리

### DIFF
--- a/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
@@ -101,11 +101,19 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "[관리자] 투표 삭제", description = "관리자가 특정 투표 기록을 강제로 삭제합니다. 관련 통계 및 유저 상태가 복구됩니다.")
-    @DeleteMapping("/admin/votes/{voteId}")
+    @Operation(summary = "[관리자] 배틀 투표 삭제")
+    @DeleteMapping("/admin/votes/battle/{voteId}")
     @PreAuthorize("hasRole('ADMIN')")
-    public ApiResponse<Void> deleteVote(@PathVariable Long voteId) {
+    public ApiResponse<Void> deleteBattleVote(@PathVariable Long voteId) {
         voteService.deleteVote(voteId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "[관리자] 퀴즈/일반투표 기록 삭제")
+    @DeleteMapping("/admin/votes/quiz-poll/{voteId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<Void> deleteQuizPollVote(@PathVariable Long voteId) {
+        quizVoteService.deleteQuizVote(voteId);
         return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteService.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteService.java
@@ -9,4 +9,5 @@ public interface QuizVoteService {
     PollVoteResponse submitPoll(Long battleId, Long userId, QuizVoteRequest request);
     QuizVoteResponse getMyQuizVote(Long battleId, Long userId);
     PollVoteResponse getMyPollVote(Long battleId, Long userId);
+    void deleteQuizVote(Long voteId);
 }

--- a/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteServiceImpl.java
@@ -99,25 +99,47 @@ public class QuizVoteServiceImpl implements QuizVoteService {
                 .orElse(null);
     }
 
+    @Transactional
+    public void deleteQuizVote(Long voteId) {
+        QuizVote quizVote = quizVoteRepository.findById(voteId)
+                .orElseThrow(() -> new CustomException(ErrorCode.VOTE_NOT_FOUND));
+
+        BattleOption option = quizVote.getSelectedOption();
+        if (option != null) {
+            option.decreaseVoteCount();
+        }
+        quizVoteRepository.delete(quizVote);
+    }
+
     private QuizVote saveOrUpdate(Long battleId, Long userId, Long optionId) {
         Battle battle = battleService.findById(battleId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        BattleOption option = battleOptionRepository.findById(optionId)
+        BattleOption newOption = battleOptionRepository.findById(optionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BATTLE_OPTION_NOT_FOUND));
 
         return quizVoteRepository.findByBattleAndUser(battle, user)
-                .map(v -> { v.updateOption(option); return v; })
+                .map(v -> {
+                    // 옵션을 바꾼다면 기존 옵션 -1, 새 옵션 +1
+                    if (!v.getSelectedOption().equals(newOption)) {
+                        v.getSelectedOption().decreaseVoteCount();
+                        newOption.increaseVoteCount();
+                        v.updateOption(newOption);
+                    }
+                    return v;
+                })
                 .orElseGet(() -> {
+                    // 처음 투표한다면 새 옵션 +1
                     battle.addParticipant();
+                    newOption.increaseVoteCount();
                     return quizVoteRepository.save(
-                            QuizVote.builder().user(user).battle(battle).selectedOption(option).build());
+                            QuizVote.builder().user(user).battle(battle).selectedOption(newOption).build());
                 });
-    }
+        }
 
     private List<QuizVoteResponse.OptionStat> calcStats(Battle battle, long totalCount) {
         return battleOptionRepository.findByBattle(battle).stream().map(o -> {
-            long count = quizVoteRepository.countByBattleAndSelectedOption(battle, o);
+            long count = (o.getVoteCount() == null) ? 0L : o.getVoteCount();
             double ratio = totalCount == 0 ? 0.0 : Math.round((double) count / totalCount * 1000) / 10.0;
             return new QuizVoteResponse.OptionStat(
                     o.getId(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- Ex) - #이슈번호 -->
<!-- 연관된 이슈 번호를 링크 형태로 작성하세요 -->
- #130 

## 📌 공유 사항
1. `BattleOption`에 voteCount를 캐싱하여 매 통계 조회 시 발생하던 집계 쿼리를 제거했습니다.
2. 옵션 변경 투표 시 기존 옵션 `-1`, 새 옵션 `+1`로 정합성을 보장합니다.
3. 관리자 삭제 엔드포인트가 `/admin/votes/battle/{voteId}`와 `/admin/votes/quiz-poll/{voteId}`로 분리되어 타입별 독립 처리가 가능합니다.

## ✅ 체크리스트
- [X] Reviewer에 팀원들을 선택했나요?
- [X] Assignees에 본인을 선택했나요?
- [X] 컨벤션에 맞는 Type을 선택했나요?
- [X] Development에 이슈를 연동했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?

## 📸 스크린샷
<!-- Swagger, Postman, JUnit 테스트 화면 첨부 -->
<!-- 기능 동작 화면이나 테스트 결과 캡처를 첨부하면 좋습니다 -->
### 퀴즈 투표 응답 (`voteCount` 캐싱)
### `/api/vi/battles/{battleId}/quiz-vote/me`
<img width="673" height="466" alt="퀴즈 투표 응답" src="https://github.com/user-attachments/assets/8d452dc5-5dfc-472a-95a1-930fbd5cf90d" />

### 퀴즈(`QUIZ`), 일반 투표(`VOTE`) 관리자 삭제 `API` 구현
### `/api/v1/admin/votes/quiz-poll/{voteId}`
<img width="1423" height="803" alt="퀴즈, 일반 투표 관리자 삭제 API 구현" src="https://github.com/user-attachments/assets/a2b9aaae-3296-490f-8456-466447f0d6eb" />

## 📝 작업 내용

### ✨ Feat
| 내용 | 파일 |
|------|------|
| `deleteQuizVote()` 인터페이스 및 구현체 추가 | `QuizVoteService.java`<br>`QuizVoteServiceImpl.java` |
| 관리자 삭제 엔드포인트 타입별 분리 | `VoteController.java` |
| `saveOrUpdate()` 옵션 변경 시 voteCount 증감 처리 | `QuizVoteServiceImpl.java` |
| `calcStats()` 집계 쿼리 → `voteCount` 직접 참조 | `QuizVoteServiceImpl.java` |