### PR TITLE
#137 [Hotfix] QuizVoteResponse.OptionStat stance 필드 누락 긴급 수정

### DIFF
--- a/src/main/java/com/swyp/picke/domain/vote/dto/response/QuizVoteResponse.java
+++ b/src/main/java/com/swyp/picke/domain/vote/dto/response/QuizVoteResponse.java
@@ -8,5 +8,12 @@ public record QuizVoteResponse(
         long totalCount,
         List<OptionStat> stats
 ) {
-    public record OptionStat(Long optionId, String label, String title, Boolean isCorrect, long voteCount, double ratio) {}
+    public record OptionStat(Long optionId,
+                             String label,
+                             String title,
+                             Boolean isCorrect,
+                             long voteCount,
+                             double ratio,
+                             String stance
+    ) {}
 }

--- a/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/QuizVoteServiceImpl.java
@@ -89,9 +89,12 @@ public class QuizVoteServiceImpl implements QuizVoteService {
                         calcStats(battle, totalCount)
                 ))
                 .orElseGet(() -> {
-                    // [투표 전] 전체 참여자 수(totalCount)는 보여주되, 개별 통계(voteCount, ratio)는 0으로 숨김
+                    // [투표 전] 전체 참여자 수(totalCount), 선택지 설명(stance)는 보여주되, 개별 통계(voteCount, ratio)는 0으로 숨김
                     List<QuizVoteResponse.OptionStat> blindStats = battleOptionRepository.findByBattle(battle).stream()
-                            .map(o -> new QuizVoteResponse.OptionStat(o.getId(), o.getLabel().name(), o.getTitle(), o.getIsCorrect(), 0L, 0.0))
+                            .map(o -> new QuizVoteResponse.OptionStat(
+                                    o.getId(), o.getLabel().name(), o.getTitle(),
+                                    o.getIsCorrect(), 0L, 0.0, o.getStance()
+                            ))
                             .toList();
                     return new QuizVoteResponse(battleId, null, totalCount, blindStats);
                 });
@@ -183,7 +186,8 @@ public class QuizVoteServiceImpl implements QuizVoteService {
                     o.getTitle(),
                     o.getIsCorrect(),
                     count,
-                    ratio
+                    ratio,
+                    null
             );
         }).toList();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- Ex) - #이슈번호 -->
<!-- 연관된 이슈 번호를 링크 형태로 작성하세요 -->
- #137 

## 📌 공유 사항
<!-- 팀원에게 공유할 내용이나 참고 사항 작성 -->
<!-- 노션 환경 설정 파일 확인 부탁드립니다! -->
**1. 고도화 때 예은님과 함께 작업한 후에 Merge를 진행하기로 해서 Merge는 하지 말아주세요!!!**
2. 배포 후 `OptionStat`에 `stance` 필드 누락이 확인되어 긴급 수정합니다.
3. 투표 전(blindStats)은 실제 `stance` 값을, `calcStats`는 `null`을 반환합니다.

## ✅ 체크리스트
<!-- PR 제출 전에 체크해야 할 사항들 -->
- [X] Reviewer에 팀원들을 선택했나요?
- [X] Assignees에 본인을 선택했나요?
- [X] 컨벤션에 맞는 Type을 선택했나요?
- [X] Development에 이슈를 연동했나요?
- [X] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [X] 컨벤션을 지키고 있나요?
- [X] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [X] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
<!-- Swagger, Postman, JUnit 테스트 화면 첨부 -->
<!-- 기능 동작 화면이나 테스트 결과 캡처를 첨부하면 좋습니다 -->
### 퀴즈 투표 후 응답 : 선택지 설명 `stance` 안 보임 처리
### `POST /api/v1/battles/{battleId}/quiz-vote`
<img width="1418" height="498" alt="POST 퀴즈 투표 후에 선택지 설명 stance 안 보임 처리" src="https://github.com/user-attachments/assets/13563b1e-43a4-4def-9885-56a9324688ee" />

### 퀴즈 투표 전 조회 : 선택지 설명 `stance` 보임 처리
### `GET /api/v1/battles/{battleId}/quiz-vote/me`
<img width="1416" height="494" alt="GET 퀴즈 투표 전 선택지 설명 stance 보임" src="https://github.com/user-attachments/assets/ac85e21f-0f7c-4a66-89f0-c52c062ad56d" />

### 퀴즈 투표 후 조회 : `stance` 안 보임 처리
### `GET /api/v1/battles/{battleId}/quiz-vote/me`
<img width="1416" height="499" alt="GET 퀴즈 투표 선택 후에 stance 안 보임" src="https://github.com/user-attachments/assets/f0636dd9-442a-4e7b-bdd7-90283448e935" />

## 💬 리뷰 요구사항
<!-- 리뷰어에게 요청하는 구체적인 사항 작성 -->
<!-- 종료 의도 판단을 Java 키워드 → AI 2차 검증 구조로 설계했는데
해당 구조가 유지보수 및 확장 측면에서 적절한지 의견 부탁드립니다. -->
> 없음

## 📝 작업 내용
<!-- 이번 PR/이슈에서 실제 수행한 작업 내용을 작성하세요 -->

### 🚑 Hotfix
| 내용 | 파일 |
|------|------|
| `OptionStat`에 `stance` 필드 추가 | `QuizVoteResponse.java` |
| `blindStats` 및 `calcStats stance` 처리 | `QuizVoteServiceImpl.java` |