### PR TITLE
#143 [Feat] 마이페이지 리캡 공유 API 추가

### DIFF
--- a/docs/api-specs/user-api.md
+++ b/docs/api-specs/user-api.md
@@ -236,6 +236,62 @@
 }
 ```
 
+### 3.5 `GET /api/v1/share/recap`
+
+현재 로그인한 사용자의 리캡 공유 키 발급.
+이미 발급된 키가 있으면 동일 키를 재사용합니다.
+
+응답:
+
+```json
+{
+  "statusCode": 200,
+  "data": {
+    "shareKey": "550e8400-e29b-41d4-a716-446655440000"
+  },
+  "error": null
+}
+```
+
+### 3.6 `GET /api/v1/share/recap/{shareKey}`
+
+공유 키로 다른 사용자의 리캡 조회.
+인증 없이 호출 가능합니다.
+
+응답:
+
+```json
+{
+  "statusCode": 200,
+  "data": {
+    "my_card": {
+      "philosopher_type": "SOCRATES"
+    },
+    "best_match_card": {
+      "philosopher_type": "PLATO"
+    },
+    "worst_match_card": {
+      "philosopher_type": "MARX"
+    },
+    "scores": {
+      "principle": 88,
+      "reason": 74,
+      "individual": 62,
+      "change": 45,
+      "inner": 30,
+      "ideal": 15
+    },
+    "preference_report": {
+      "total_participation": 47,
+      "opinion_changes": 12,
+      "battle_win_rate": 68,
+      "favorite_topics": []
+    }
+  },
+  "error": null
+}
+```
+
 ### 3.5 `GET /api/v1/me/notification-settings`
 
 마이페이지 알림 설정 조회.

--- a/src/main/java/com/swyp/picke/domain/oauth/jwt/JwtFilter.java
+++ b/src/main/java/com/swyp/picke/domain/oauth/jwt/JwtFilter.java
@@ -45,6 +45,7 @@ public class JwtFilter extends OncePerRequestFilter {
             "/result",           // 공유 링크 리다이렉트
             "/report",          // 철학자 리포트 딥링크
             "/battle",          // 배틀 딥링크
+            "/api/v1/share/recap/", // 공개 리캡 공유 조회
             "/.well-known",     // Android App Links 인증
             "/api/v1/resources" // 이미지, 오디오 파일 (Presigned URL)
     );

--- a/src/main/java/com/swyp/picke/domain/share/controller/ShareApiController.java
+++ b/src/main/java/com/swyp/picke/domain/share/controller/ShareApiController.java
@@ -1,9 +1,13 @@
 package com.swyp.picke.domain.share.controller;
 
+import com.swyp.picke.domain.share.dto.response.RecapShareKeyResponse;
+import com.swyp.picke.domain.share.service.ShareService;
+import com.swyp.picke.domain.user.dto.response.RecapResponse;
 import com.swyp.picke.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +22,8 @@ public class ShareApiController {
     @Value("${picke.baseUrl}")
     private String baseUrl;
 
+    private final ShareService shareService;
+
     @GetMapping("/report")
     public ApiResponse<Map<String, String>> getReportShareUrl(@RequestParam Long reportId) {
         String shareUrl = baseUrl + "/report/" + reportId;
@@ -28,5 +34,15 @@ public class ShareApiController {
     public ApiResponse<Map<String, String>> getBattleShareUrl(@RequestParam Long battleId) {
         String shareUrl = baseUrl + "/battle/" + battleId;
         return ApiResponse.onSuccess(Map.of("shareUrl", shareUrl));
+    }
+
+    @GetMapping("/recap")
+    public ApiResponse<RecapShareKeyResponse> getRecapShareKey() {
+        return ApiResponse.onSuccess(shareService.getRecapShareKey());
+    }
+
+    @GetMapping("/recap/{shareKey}")
+    public ApiResponse<RecapResponse> getSharedRecap(@PathVariable String shareKey) {
+        return ApiResponse.onSuccess(shareService.getSharedRecap(shareKey));
     }
 }

--- a/src/main/java/com/swyp/picke/domain/share/dto/response/RecapShareKeyResponse.java
+++ b/src/main/java/com/swyp/picke/domain/share/dto/response/RecapShareKeyResponse.java
@@ -1,0 +1,6 @@
+package com.swyp.picke.domain.share.dto.response;
+
+public record RecapShareKeyResponse(
+        String shareKey
+) {
+}

--- a/src/main/java/com/swyp/picke/domain/share/service/ShareService.java
+++ b/src/main/java/com/swyp/picke/domain/share/service/ShareService.java
@@ -1,0 +1,57 @@
+package com.swyp.picke.domain.share.service;
+
+import com.swyp.picke.domain.share.dto.response.RecapShareKeyResponse;
+import com.swyp.picke.domain.user.dto.response.RecapResponse;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.entity.UserProfile;
+import com.swyp.picke.domain.user.repository.UserProfileRepository;
+import com.swyp.picke.domain.user.service.MypageService;
+import com.swyp.picke.domain.user.service.UserService;
+import com.swyp.picke.global.common.exception.CustomException;
+import com.swyp.picke.global.common.exception.ErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShareService {
+
+    private final UserService userService;
+    private final UserProfileRepository userProfileRepository;
+    private final MypageService mypageService;
+
+    @Transactional
+    public RecapShareKeyResponse getRecapShareKey() {
+        User user = userService.findCurrentUser();
+        UserProfile profile = userService.findUserProfile(user.getId());
+
+        ensureRecapExists(user.getId());
+
+        if (profile.getRecapShareKey() == null || profile.getRecapShareKey().isBlank()) {
+            profile.updateRecapShareKey(UUID.randomUUID().toString());
+        }
+
+        return new RecapShareKeyResponse(profile.getRecapShareKey());
+    }
+
+    public RecapResponse getSharedRecap(String shareKey) {
+        UserProfile profile = userProfileRepository.findByRecapShareKey(shareKey)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECAP_NOT_FOUND));
+
+        RecapResponse recap = mypageService.findRecapByUserId(profile.getUser().getId());
+        if (recap == null) {
+            throw new CustomException(ErrorCode.RECAP_NOT_FOUND);
+        }
+
+        return recap;
+    }
+
+    private void ensureRecapExists(Long userId) {
+        if (mypageService.findRecapByUserId(userId) == null) {
+            throw new CustomException(ErrorCode.RECAP_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/swyp/picke/domain/user/entity/UserProfile.java
@@ -37,13 +37,17 @@ public class UserProfile extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PhilosopherType philosopherType;
 
+    @Column(name = "recap_share_key", unique = true, length = 36)
+    private String recapShareKey;
+
     private BigDecimal mannerTemperature;
 
     @Builder
-    private UserProfile(User user, String nickname, CharacterType characterType, BigDecimal mannerTemperature) {
+    private UserProfile(User user, String nickname, CharacterType characterType, String recapShareKey, BigDecimal mannerTemperature) {
         this.user = user;
         this.nickname = nickname;
         this.characterType = Objects.requireNonNull(characterType, "characterType must not be null");
+        this.recapShareKey = recapShareKey;
         this.mannerTemperature = mannerTemperature;
     }
 
@@ -58,5 +62,9 @@ public class UserProfile extends BaseEntity {
 
     public void updatePhilosopherType(PhilosopherType philosopherType) {
         this.philosopherType = philosopherType;
+    }
+
+    public void updateRecapShareKey(String recapShareKey) {
+        this.recapShareKey = recapShareKey;
     }
 }

--- a/src/main/java/com/swyp/picke/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/swyp/picke/domain/user/repository/UserProfileRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
 
     Optional<UserProfile> findByUserId(Long userId);
+
+    Optional<UserProfile> findByRecapShareKey(String recapShareKey);
 }

--- a/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
@@ -88,8 +88,11 @@ public class MypageService {
 
     public RecapResponse getRecap() {
         User user = userService.findCurrentUser();
-        UserProfile profile = userService.findUserProfile(user.getId());
+        return findRecapByUserId(user.getId());
+    }
 
+    public RecapResponse findRecapByUserId(Long userId) {
+        UserProfile profile = userService.findUserProfile(userId);
         PhilosopherType philosopherType = profile.getPhilosopherType();
         if (philosopherType == null) {
             return null;
@@ -108,7 +111,7 @@ public class MypageService {
                 philosopherType.getIdeal()
         );
 
-        RecapResponse.PreferenceReport preferenceReport = buildPreferenceReport(user.getId());
+        RecapResponse.PreferenceReport preferenceReport = buildPreferenceReport(userId);
 
         return new RecapResponse(myCard, bestMatchCard, worstMatchCard, scores, preferenceReport);
     }
@@ -360,6 +363,5 @@ public class MypageService {
         return s3PresignedUrlService.generatePresignedUrl(imageKey);
     }
 }
-
 
 

--- a/src/main/java/com/swyp/picke/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/swyp/picke/global/common/exception/ErrorCode.java
@@ -109,7 +109,8 @@ public enum ErrorCode {
     REWARD_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "REWARD_401", "AdMob 서명 검증에 실패했습니다."),
 
     // MyPage
-    PHILOSOPHER_CALC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_500_PHIL", "철학자 유형을 계산할 수 없습니다.");
+    PHILOSOPHER_CALC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_500_PHIL", "철학자 유형을 계산할 수 없습니다."),
+    RECAP_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_RECAP", "존재하지 않는 리캡입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/swyp/picke/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/admin/picke/**").permitAll()
 
                         // 3. 단순 조회성 및 진행상태 업데이트 REST API
+                        .requestMatchers(HttpMethod.GET, "/api/v1/share/recap/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/tags", "/api/v1/battles/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/battles/**").authenticated()
 

--- a/src/test/java/com/swyp/picke/domain/share/controller/ShareApiIntegrationTest.java
+++ b/src/test/java/com/swyp/picke/domain/share/controller/ShareApiIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.swyp.picke.domain.share.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp.picke.domain.oauth.jwt.JwtProvider;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.entity.UserProfile;
+import com.swyp.picke.domain.user.enums.CharacterType;
+import com.swyp.picke.domain.user.enums.PhilosopherType;
+import com.swyp.picke.domain.user.enums.UserRole;
+import com.swyp.picke.domain.user.enums.UserStatus;
+import com.swyp.picke.domain.user.repository.UserProfileRepository;
+import com.swyp.picke.domain.user.repository.UserRepository;
+import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ShareApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    @MockitoBean
+    private S3Client s3Client;
+
+    @MockitoBean
+    private S3PresignedUrlService s3PresignedUrlService;
+
+    @Test
+    @DisplayName("인증 사용자는 공유 키를 발급받고 비로그인 사용자는 그 키로 리캡을 조회할 수 있다")
+    void recap_share_key_and_public_lookup_work() throws Exception {
+        when(s3PresignedUrlService.generatePresignedUrl(anyString())).thenReturn("https://presigned-url");
+
+        User user = userRepository.save(
+                User.builder()
+                        .userTag("user-" + UUID.randomUUID().toString().substring(0, 8))
+                        .nickname("nickname")
+                        .role(UserRole.USER)
+                        .status(UserStatus.ACTIVE)
+                        .build()
+        );
+
+        UserProfile profile = UserProfile.builder()
+                .user(user)
+                .nickname("recap-user")
+                .characterType(CharacterType.OWL)
+                .mannerTemperature(BigDecimal.valueOf(36.5))
+                .build();
+        profile.updatePhilosopherType(PhilosopherType.KANT);
+        userProfileRepository.save(profile);
+
+        String token = jwtProvider.createAccessToken(user.getId(), "USER");
+
+        MvcResult shareKeyResult = mockMvc.perform(get("/api/v1/share/recap")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.shareKey").isNotEmpty())
+                .andReturn();
+
+        Map<?, ?> body = objectMapper.readValue(shareKeyResult.getResponse().getContentAsByteArray(), Map.class);
+        Map<?, ?> data = (Map<?, ?>) body.get("data");
+        String shareKey = (String) data.get("shareKey");
+
+        mockMvc.perform(get("/api/v1/share/recap/{shareKey}", shareKey))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.myCard.philosopherType").value("KANT"))
+                .andExpect(jsonPath("$.data.preferenceReport.totalParticipation").value(0));
+    }
+
+    @Test
+    @DisplayName("공유 키 발급 API는 인증이 필요하다")
+    void recap_share_key_requires_authentication() throws Exception {
+        mockMvc.perform(get("/api/v1/share/recap"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/swyp/picke/domain/share/service/ShareServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/share/service/ShareServiceTest.java
@@ -1,0 +1,117 @@
+package com.swyp.picke.domain.share.service;
+
+import com.swyp.picke.domain.share.dto.response.RecapShareKeyResponse;
+import com.swyp.picke.domain.user.dto.response.RecapResponse;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.entity.UserProfile;
+import com.swyp.picke.domain.user.enums.CharacterType;
+import com.swyp.picke.domain.user.enums.UserRole;
+import com.swyp.picke.domain.user.enums.UserStatus;
+import com.swyp.picke.domain.user.repository.UserProfileRepository;
+import com.swyp.picke.domain.user.service.MypageService;
+import com.swyp.picke.domain.user.service.UserService;
+import com.swyp.picke.global.common.exception.CustomException;
+import com.swyp.picke.global.common.exception.ErrorCode;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShareServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private MypageService mypageService;
+
+    @InjectMocks
+    private ShareService shareService;
+
+    @Test
+    @DisplayName("리캡 공유 키는 최초 1회 생성 후 재사용된다")
+    void getRecapShareKey_generates_and_reuses_key() {
+        User user = createUser(1L, "tag");
+        UserProfile profile = createProfile(user, "nick");
+
+        when(userService.findCurrentUser()).thenReturn(user);
+        when(userService.findUserProfile(1L)).thenReturn(profile);
+        when(mypageService.findRecapByUserId(1L)).thenReturn(createRecap());
+
+        RecapShareKeyResponse first = shareService.getRecapShareKey();
+        RecapShareKeyResponse second = shareService.getRecapShareKey();
+
+        assertThat(first.shareKey()).isNotBlank();
+        assertThat(second.shareKey()).isEqualTo(first.shareKey());
+        assertThat(profile.getRecapShareKey()).isEqualTo(first.shareKey());
+    }
+
+    @Test
+    @DisplayName("리캡이 없으면 공유 키를 발급하지 않는다")
+    void getRecapShareKey_throws_when_recap_missing() {
+        User user = createUser(1L, "tag");
+        UserProfile profile = createProfile(user, "nick");
+
+        when(userService.findCurrentUser()).thenReturn(user);
+        when(userService.findUserProfile(1L)).thenReturn(profile);
+        when(mypageService.findRecapByUserId(1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> shareService.getRecapShareKey())
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RECAP_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공유 키로 타인의 리캡을 조회한다")
+    void getSharedRecap_returns_recap() {
+        User user = createUser(2L, "other");
+        UserProfile profile = createProfile(user, "other-nick");
+        profile.updateRecapShareKey("share-key");
+        RecapResponse recap = createRecap();
+
+        when(userProfileRepository.findByRecapShareKey("share-key")).thenReturn(Optional.of(profile));
+        when(mypageService.findRecapByUserId(2L)).thenReturn(recap);
+
+        RecapResponse response = shareService.getSharedRecap("share-key");
+
+        assertThat(response).isSameAs(recap);
+    }
+
+    private User createUser(Long id, String userTag) {
+        User user = User.builder()
+                .userTag(userTag)
+                .nickname("nickname")
+                .role(UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private UserProfile createProfile(User user, String nickname) {
+        return UserProfile.builder()
+                .user(user)
+                .nickname(nickname)
+                .characterType(CharacterType.OWL)
+                .mannerTemperature(BigDecimal.valueOf(36.5))
+                .build();
+    }
+
+    private RecapResponse createRecap() {
+        return new RecapResponse(null, null, null, null, null);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #143

## 📝 작업 내용

### ✨ Feat
| 내용 | 파일 |
|------|------|
| 현재 로그인 사용자의 recap 공유 키 발급 API 추가 (`GET /api/v1/share/recap`) | `ShareApiController.java`, `ShareService.java`, `RecapShareKeyResponse.java` |
| 공유 키 기반 공개 recap 조회 API 추가 (`GET /api/v1/share/recap/{shareKey}`) | `ShareApiController.java`, `ShareService.java` |
| 사용자별 재사용 가능한 `recapShareKey` 저장 필드 및 조회 로직 추가 | `UserProfile.java`, `UserProfileRepository.java` |

### ♻️ Refactor
| 내용 | 파일 |
|------|------|
| 기존 recap 조립 로직을 사용자 ID 기반 공용 메서드로 분리 | `MypageService.java` |
|  |  |

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| 공개 공유 조회 경로가 JWT 필터에서 401 되지 않도록 whitelist 반영 | `JwtFilter.java`, `SecurityConfig.java` |
| recap 부재 상황을 공유 API에서 명확히 처리하도록 예외 코드 추가 | `ErrorCode.java` |

## 📌 공유 사항
> 1. `shareUrl`은 제외하고 `shareKey`만 반환하도록 구현했습니다.
> 2. 공유 키는 사용자별 1개를 재사용하며, 최초 호출 시에만 생성됩니다.
> 3. 공개 조회 응답은 기존 `/api/v1/me/recap`과 동일한 `RecapResponse`를 사용합니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
- 없음
- 테스트 실행: `./gradlew test --tests com.swyp.picke.domain.user.service.MypageServiceTest --tests com.swyp.picke.domain.share.service.ShareServiceTest --tests com.swyp.picke.domain.share.controller.ShareApiIntegrationTest`

## 💬 리뷰 요구사항
> 1. 공유 키를 사용자별 고정 재사용 방식으로 둔 점이 현재 요구사항에 맞는지 확인 부탁드립니다.
> 2. 공개 조회 경로를 `/api/v1/share/recap/{shareKey}`로 둔 네이밍이 적절한지 봐주세요.
