### PR TITLE
#180 [Fix] 지난 배틀 사전투표 크레딧 차감 로직 추가

### DIFF
--- a/src/main/java/com/swyp/picke/domain/user/enums/CreditType.java
+++ b/src/main/java/com/swyp/picke/domain/user/enums/CreditType.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum CreditType {
     BATTLE_VOTE(5),        // 배틀 참여 보상: 사후 투표 완료 시 즉시 지급
+    BATTLE_ENTRY(-10),     // 지난 배틀 이용 비용: 사전 투표 최초 진입 시 차감
     MAJORITY_WIN(10),      // 다수결 보상: 월요일 배치, 2주 전 배틀 TOP≥10 대상
     BEST_COMMENT(50),      // 베댓 보상: 월요일 배치, 2주 전 배틀 좋아요 1위
     WEEKLY_CHARGE(40),     // 주간 자동 충전: 매주 월요일 00:00 활성 사용자 전체

--- a/src/main/java/com/swyp/picke/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/swyp/picke/domain/user/repository/UserRepository.java
@@ -21,5 +21,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("update User u set u.credit = u.credit + :amount where u.id = :id")
     int incrementCredit(@Param("id") Long id, @Param("amount") int amount);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update User u set u.credit = u.credit - :amount where u.id = :id and u.credit >= :amount")
+    int decrementCreditIfEnough(@Param("id") Long id, @Param("amount") int amount);
+
     List<User> findAllByStatus(UserStatus status);
 }

--- a/src/main/java/com/swyp/picke/domain/user/service/CreditService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/CreditService.java
@@ -50,7 +50,7 @@ public class CreditService {
      * CreditType의 기본 포인트가 아닌 가변 포인트가 필요한 경우(FREE_CHARGE 랜덤 박스 등)에서 사용.
      * 예: creditService.addCredit(userId, CreditType.FREE_CHARGE, 15, boxId);
      *
-     * 적립이 성공하면 User.credit 캐시를 동기 증감하여 {@link #getTotalPoints}가 전체 히스토리를 재집계하지 않도록 한다.
+     * 적립/차감이 성공하면 User.credit 캐시를 동기 증감하여 {@link #getTotalPoints}가 전체 히스토리를 재집계하지 않도록 한다.
      * (user, creditType, referenceId) 중복 시 조용히 무시(멱등).
      */
     @Transactional
@@ -75,7 +75,15 @@ public class CreditService {
             }
             throw new CustomException(ErrorCode.CREDIT_SAVE_FAILED);
         }
-        if (userRepository.incrementCredit(userId, amount) == 0) {
+
+        int updated = amount >= 0
+                ? userRepository.incrementCredit(userId, amount)
+                : userRepository.decrementCreditIfEnough(userId, -amount);
+
+        if (updated == 0) {
+            if (amount < 0) {
+                throw new CustomException(ErrorCode.CREDIT_NOT_ENOUGH);
+            }
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
     }

--- a/src/main/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImpl.java
@@ -21,7 +21,9 @@ import com.swyp.picke.domain.vote.repository.BattleVoteRepository;
 import com.swyp.picke.domain.vote.sse.VoteUpdatedEvent;
 import com.swyp.picke.global.common.exception.CustomException;
 import com.swyp.picke.global.common.exception.ErrorCode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BattleVoteServiceImpl implements BattleVoteService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final BattleVoteRepository battleVoteRepository;
     private final BattleService battleService;
@@ -122,6 +126,9 @@ public class BattleVoteServiceImpl implements BattleVoteService {
             vote = existingVote.get();
             vote.updatePreVote(option);
         } else {
+            if (shouldChargeBattleEntryCredit(battle)) {
+                creditService.addCredit(user.getId(), CreditType.BATTLE_ENTRY, battle.getId());
+            }
             vote = BattleVote.createPreVote(user, battle, option);
             battleVoteRepository.save(vote);
             battle.addParticipant();
@@ -190,5 +197,10 @@ public class BattleVoteServiceImpl implements BattleVoteService {
         vote.completeTts();
 
         userBattleService.upsertStep(user, battle, UserBattleStep.POST_VOTE);
+    }
+
+    private boolean shouldChargeBattleEntryCredit(Battle battle) {
+        LocalDate today = LocalDate.now(KST);
+        return battle.getTargetDate() == null || !battle.getTargetDate().isEqual(today);
     }
 }

--- a/src/test/java/com/swyp/picke/domain/user/service/CreditServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/user/service/CreditServiceTest.java
@@ -107,6 +107,35 @@ class CreditServiceTest {
     }
 
     @Test
+    @DisplayName("차감 시 잔액이 충분하면 credit 캐시를 감소시킨다")
+    void addCredit_negativeAmount_decrementsCreditWhenEnough() {
+        User user = newUser(1L, 20);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.decrementCreditIfEnough(1L, 10)).thenReturn(1);
+
+        creditService.addCredit(1L, CreditType.BATTLE_ENTRY, -10, 99L);
+
+        verify(userRepository).decrementCreditIfEnough(1L, 10);
+        verify(userRepository, never()).incrementCredit(1L, -10);
+    }
+
+    @Test
+    @DisplayName("차감 시 잔액이 부족하면 CREDIT_NOT_ENOUGH 를 던진다")
+    void addCredit_negativeAmount_throwsWhenInsufficient() {
+        User user = newUser(1L, 5);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.decrementCreditIfEnough(1L, 10)).thenReturn(0);
+
+        assertThatThrownBy(() -> creditService.addCredit(1L, CreditType.BATTLE_ENTRY, -10, 99L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CREDIT_NOT_ENOUGH);
+
+        verify(userRepository).decrementCreditIfEnough(1L, 10);
+        verify(userRepository, never()).incrementCredit(1L, -10);
+    }
+
+    @Test
     @DisplayName("중복이 아닌 데이터 무결성 오류는 CREDIT_SAVE_FAILED 로 재기동하고 캐시도 증가시키지 않는다")
     void addCredit_nonDuplicateIntegrityFailure_rethrows() {
         User user = newUser(1L, 3);
@@ -122,6 +151,7 @@ class CreditServiceTest {
                 .isEqualTo(ErrorCode.CREDIT_SAVE_FAILED);
 
         verify(userRepository, never()).incrementCredit(1L, 10);
+        verify(userRepository, never()).decrementCreditIfEnough(1L, 10);
     }
 
     @Test

--- a/src/test/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImplTest.java
+++ b/src/test/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImplTest.java
@@ -19,6 +19,7 @@ import com.swyp.picke.domain.vote.dto.request.VoteRequest;
 import com.swyp.picke.domain.vote.dto.response.VoteResultResponse;
 import com.swyp.picke.domain.vote.entity.BattleVote;
 import com.swyp.picke.domain.vote.repository.BattleVoteRepository;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,9 +27,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,13 +56,84 @@ class BattleVoteServiceImplTest {
     @Mock
     private CreditService creditService;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private BattleVoteServiceImpl battleVoteService;
 
     @Test
+    @DisplayName("오늘 배틀이 아니면 최초 사전 투표 시 BATTLE_ENTRY 크레딧을 차감한다")
+    void preVote_chargesBattleEntryCreditForPastBattle() {
+        Battle battle = battle(100L, LocalDate.now().minusDays(1));
+        User user = user(10L);
+        BattleOption option = option(201L, battle, BattleOptionLabel.A);
+
+        when(battleService.findById(100L)).thenReturn(battle);
+        when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+        when(battleOptionRepository.findById(201L)).thenReturn(Optional.of(option));
+        when(battleVoteRepository.findByBattleAndUser(battle, user)).thenReturn(Optional.empty());
+        when(userBattleService.getUserBattleStatus(user, battle))
+                .thenReturn(new UserBattleStatusResponse(100L, UserBattleStep.NONE));
+
+        VoteResultResponse response = battleVoteService.preVote(100L, 10L, new VoteRequest(201L));
+
+        assertThat(response.status()).isEqualTo(UserBattleStep.PRE_VOTE);
+        verify(creditService).addCredit(10L, CreditType.BATTLE_ENTRY, 100L);
+        verify(userBattleService).upsertStep(user, battle, UserBattleStep.PRE_VOTE);
+    }
+
+    @Test
+    @DisplayName("오늘 배틀이면 최초 사전 투표 시 크레딧을 차감하지 않는다")
+    void preVote_doesNotChargeBattleEntryCreditForTodayBattle() {
+        Battle battle = battle(100L, LocalDate.now());
+        User user = user(10L);
+        BattleOption option = option(201L, battle, BattleOptionLabel.A);
+
+        when(battleService.findById(100L)).thenReturn(battle);
+        when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+        when(battleOptionRepository.findById(201L)).thenReturn(Optional.of(option));
+        when(battleVoteRepository.findByBattleAndUser(battle, user)).thenReturn(Optional.empty());
+        when(userBattleService.getUserBattleStatus(user, battle))
+                .thenReturn(new UserBattleStatusResponse(100L, UserBattleStep.NONE));
+
+        VoteResultResponse response = battleVoteService.preVote(100L, 10L, new VoteRequest(201L));
+
+        assertThat(response.status()).isEqualTo(UserBattleStep.PRE_VOTE);
+        verify(creditService, never()).addCredit(10L, CreditType.BATTLE_ENTRY, 100L);
+    }
+
+    @Test
+    @DisplayName("이미 사전 투표한 배틀이면 옵션 변경 시 추가 차감하지 않는다")
+    void preVote_doesNotChargeAgainWhenVoteAlreadyExists() {
+        Battle battle = battle(100L, LocalDate.now().minusDays(1));
+        User user = user(10L);
+        BattleOption oldOption = option(200L, battle, BattleOptionLabel.B);
+        BattleOption newOption = option(201L, battle, BattleOptionLabel.A);
+        BattleVote vote = BattleVote.builder()
+                .user(user)
+                .battle(battle)
+                .preVoteOption(oldOption)
+                .build();
+
+        when(battleService.findById(100L)).thenReturn(battle);
+        when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+        when(battleOptionRepository.findById(201L)).thenReturn(Optional.of(newOption));
+        when(battleVoteRepository.findByBattleAndUser(battle, user)).thenReturn(Optional.of(vote));
+        when(userBattleService.getUserBattleStatus(user, battle))
+                .thenReturn(new UserBattleStatusResponse(100L, UserBattleStep.PRE_VOTE));
+
+        VoteResultResponse response = battleVoteService.preVote(100L, 10L, new VoteRequest(201L));
+
+        assertThat(response.status()).isEqualTo(UserBattleStep.PRE_VOTE);
+        assertThat(vote.getPreVoteOption()).isEqualTo(newOption);
+        verify(creditService, never()).addCredit(10L, CreditType.BATTLE_ENTRY, 100L);
+    }
+
+    @Test
     @DisplayName("사후 투표 완료 시 참여 보상 크레딧을 지급한다")
     void postVote_rewardsBattleParticipationCredit() {
-        Battle battle = battle(100L);
+        Battle battle = battle(100L, null);
         User user = user(10L);
         BattleOption preOption = option(201L, battle, BattleOptionLabel.A);
         BattleOption postOption = option(202L, battle, BattleOptionLabel.B);
@@ -86,10 +160,11 @@ class BattleVoteServiceImplTest {
         verify(creditService).addCredit(10L, CreditType.BATTLE_VOTE, 300L);
     }
 
-    private Battle battle(Long id) {
+    private Battle battle(Long id, LocalDate targetDate) {
         Battle battle = Battle.builder()
                 .title("battle")
                 .summary("summary")
+                .targetDate(targetDate)
                 .status(BattleStatus.PUBLISHED)
                 .build();
         ReflectionTestUtils.setField(battle, "id", id);


### PR DESCRIPTION
## 변경 사항
- 오늘이 아닌 배틀에서 최초 사전투표 시 10P를 차감하도록 추가
- 오늘의 배틀은 무료 진입을 유지
- 크레딧이 부족하면 `CREDIT_NOT_ENOUGH` 에러를 반환하도록 처리
- 이미 사전투표한 지난 배틀에서 옵션만 변경할 때는 재차감되지 않도록 처리

## 테스트
- `sh gradlew test --no-daemon`

Closes #180
