### PR TITLE
#191 [Fix] 관리자 콘텐츠 타겟 날짜 및 발행 저장 플로우 보완

### DIFF
--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleCreateRequest.java
@@ -1,6 +1,7 @@
 package com.swyp.picke.domain.admin.dto.battle.request;
 
 import com.swyp.picke.domain.battle.enums.BattleStatus;
+import java.time.LocalDate;
 import java.util.List;
 
 public record AdminBattleCreateRequest(
@@ -8,6 +9,8 @@ public record AdminBattleCreateRequest(
         String summary,
         String description,
         String thumbnailUrl,
+        LocalDate targetDate,
+        Integer audioDuration,
         BattleStatus status,
         List<Long> tagIds,
         List<AdminBattleOptionRequest> options

--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleUpdateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.swyp.picke.domain.admin.dto.battle.request;
 
 import com.swyp.picke.domain.battle.enums.BattleStatus;
+import java.time.LocalDate;
 import java.util.List;
 
 public record AdminBattleUpdateRequest(
@@ -8,6 +9,8 @@ public record AdminBattleUpdateRequest(
         String summary,
         String description,
         String thumbnailUrl,
+        LocalDate targetDate,
+        Integer audioDuration,
         BattleStatus status,
         List<Long> tagIds,
         List<AdminBattleOptionRequest> options

--- a/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollCreateRequest.java
@@ -1,11 +1,13 @@
 package com.swyp.picke.domain.admin.dto.poll.request;
 
 import com.swyp.picke.domain.poll.enums.PollStatus;
+import java.time.LocalDate;
 import java.util.List;
 
 public record AdminPollCreateRequest(
         String titlePrefix,
         String titleSuffix,
+        LocalDate targetDate,
         PollStatus status,
         List<AdminPollOptionRequest> options
 ) {

--- a/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollOptionRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollOptionRequest.java
@@ -4,7 +4,8 @@ import com.swyp.picke.domain.poll.enums.PollOptionLabel;
 
 public record AdminPollOptionRequest(
         PollOptionLabel label,
-        String title
+        String title,
+        Integer displayOrder
 ) {}
 
 

--- a/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizCreateRequest.java
@@ -1,10 +1,12 @@
 package com.swyp.picke.domain.admin.dto.quiz.request;
 
 import com.swyp.picke.domain.quiz.enums.QuizStatus;
+import java.time.LocalDate;
 import java.util.List;
 
 public record AdminQuizCreateRequest(
         String title,
+        LocalDate targetDate,
         QuizStatus status,
         List<AdminQuizOptionRequest> options
 ) {}

--- a/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizOptionRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizOptionRequest.java
@@ -6,5 +6,6 @@ public record AdminQuizOptionRequest(
         QuizOptionLabel label,
         String text,
         String detailText,
-        Boolean isCorrect
+        Boolean isCorrect,
+        Integer displayOrder
 ) {}

--- a/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
@@ -37,6 +37,8 @@ public class BattleConverter {
                 .summary(request.summary())
                 .description(request.description())
                 .thumbnailUrl(request.thumbnailUrl())
+                .targetDate(request.targetDate())
+                .audioDuration(request.audioDuration())
                 .status(request.status())
                 .creatorType(BattleCreatorType.ADMIN)
                 .creator(admin)

--- a/src/main/java/com/swyp/picke/domain/battle/entity/Battle.java
+++ b/src/main/java/com/swyp/picke/domain/battle/entity/Battle.java
@@ -109,6 +109,8 @@ public class Battle extends BaseEntity {
             String summary,
             String description,
             String thumbnailUrl,
+            LocalDate targetDate,
+            Integer audioDuration,
             BattleStatus status
     ) {
         if (title != null) {

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -302,6 +302,8 @@ public class BattleServiceImpl implements BattleService {
                 request.summary(),
                 request.description(),
                 resolvedThumbnailKey,
+                request.targetDate(),
+                request.audioDuration(),
                 request.status()
         );
         battle = battleRepository.save(battle);
@@ -379,6 +381,8 @@ public class BattleServiceImpl implements BattleService {
                 request.summary(),
                 request.description(),
                 resolvedThumbnailKey,
+                request.targetDate(),
+                request.audioDuration(),
                 request.status()
         );
 

--- a/src/main/java/com/swyp/picke/domain/poll/converter/PollConverter.java
+++ b/src/main/java/com/swyp/picke/domain/poll/converter/PollConverter.java
@@ -25,6 +25,7 @@ public class PollConverter {
         return Poll.builder()
                 .titlePrefix(request.titlePrefix())
                 .titleSuffix(request.titleSuffix())
+                .targetDate(request.targetDate())
                 .status(request.status())
                 .build();
     }

--- a/src/main/java/com/swyp/picke/domain/poll/entity/PollOption.java
+++ b/src/main/java/com/swyp/picke/domain/poll/entity/PollOption.java
@@ -48,7 +48,7 @@ public class PollOption extends BaseEntity {
     }
 
 
-    public void update(String title) {
+    public void update(String title, Integer displayOrder) {
         if (title != null) this.title = title;
         if (displayOrder != null) this.displayOrder = displayOrder;
     }

--- a/src/main/java/com/swyp/picke/domain/poll/service/PollServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/poll/service/PollServiceImpl.java
@@ -98,11 +98,14 @@ public class PollServiceImpl implements PollService {
 
         List<PollOption> savedOptions = new ArrayList<>();
         if (request.options() != null) {
-            for (AdminPollOptionRequest optionRequest : request.options()) {
+            for (int i = 0; i < request.options().size(); i++) {
+                AdminPollOptionRequest optionRequest = request.options().get(i);
+                int displayOrder = resolveDisplayOrder(optionRequest.displayOrder(), i + 1);
                 PollOption option = PollOption.builder()
                         .poll(poll)
                         .label(optionRequest.label())
                         .title(optionRequest.title())
+                        .displayOrder(displayOrder)
                         .build();
                 option = pollOptionRepository.save(option);
                 savedOptions.add(option);
@@ -132,7 +135,9 @@ public class PollServiceImpl implements PollService {
             }
 
             Set<PollOptionLabel> requestedLabels = new HashSet<>();
-            for (AdminPollOptionRequest optionRequest : request.options()) {
+            for (int i = 0; i < request.options().size(); i++) {
+                AdminPollOptionRequest optionRequest = request.options().get(i);
+                int displayOrder = resolveDisplayOrder(optionRequest.displayOrder(), i + 1);
                 requestedLabels.add(optionRequest.label());
                 PollOption option = existingOptionMap.get(optionRequest.label());
 
@@ -141,10 +146,11 @@ public class PollServiceImpl implements PollService {
                             .poll(poll)
                             .label(optionRequest.label())
                             .title(optionRequest.title())
+                            .displayOrder(displayOrder)
                             .build();
                     option = pollOptionRepository.save(option);
                 } else {
-                    option.update(optionRequest.title());
+                    option.update(optionRequest.title(), displayOrder);
                 }
             }
 
@@ -166,6 +172,13 @@ public class PollServiceImpl implements PollService {
         pollOptionRepository.deleteAll(options);
         pollRepository.delete(poll);
         return new AdminPollDeleteResponse(true, LocalDateTime.now());
+    }
+
+    private int resolveDisplayOrder(Integer requestedOrder, int fallbackOrder) {
+        if (requestedOrder == null || requestedOrder < 1) {
+            return fallbackOrder;
+        }
+        return requestedOrder;
     }
 
     private void ensureTodayPicks(LocalDate today, int requiredCount) {

--- a/src/main/java/com/swyp/picke/domain/quiz/converter/QuizConverter.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/converter/QuizConverter.java
@@ -24,6 +24,7 @@ public class QuizConverter {
     public Quiz toEntity(AdminQuizCreateRequest request) {
         return Quiz.builder()
                 .title(request.title())
+                .targetDate(request.targetDate())
                 .status(request.status())
                 .build();
     }

--- a/src/main/java/com/swyp/picke/domain/quiz/entity/QuizOption.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/entity/QuizOption.java
@@ -62,7 +62,7 @@ public class QuizOption extends BaseEntity {
         this.quiz = quiz;
     }
 
-    public void update(String text, String detailText, Boolean isCorrect) {
+    public void update(String text, String detailText, Boolean isCorrect, Integer displayOrder) {
         if (text != null) this.text = text;
         if (detailText != null) this.detailText = detailText;
         if (isCorrect != null) this.isCorrect = isCorrect;

--- a/src/main/java/com/swyp/picke/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/service/QuizServiceImpl.java
@@ -98,13 +98,16 @@ public class QuizServiceImpl implements QuizService {
 
         List<QuizOption> savedOptions = new ArrayList<>();
         if (request.options() != null) {
-            for (AdminQuizOptionRequest optionRequest : request.options()) {
+            for (int i = 0; i < request.options().size(); i++) {
+                AdminQuizOptionRequest optionRequest = request.options().get(i);
+                int displayOrder = resolveDisplayOrder(optionRequest.displayOrder(), i + 1);
                 QuizOption option = QuizOption.builder()
                         .quiz(quiz)
                         .label(optionRequest.label())
                         .text(optionRequest.text())
                         .detailText(optionRequest.detailText())
                         .isCorrect(optionRequest.isCorrect())
+                        .displayOrder(displayOrder)
                         .build();
                 option = quizOptionRepository.save(option);
                 savedOptions.add(option);
@@ -129,7 +132,9 @@ public class QuizServiceImpl implements QuizService {
             }
 
             Set<QuizOptionLabel> requestedLabels = new HashSet<>();
-            for (AdminQuizOptionRequest optionRequest : request.options()) {
+            for (int i = 0; i < request.options().size(); i++) {
+                AdminQuizOptionRequest optionRequest = request.options().get(i);
+                int displayOrder = resolveDisplayOrder(optionRequest.displayOrder(), i + 1);
                 requestedLabels.add(optionRequest.label());
                 QuizOption option = existingOptionMap.get(optionRequest.label());
 
@@ -140,13 +145,15 @@ public class QuizServiceImpl implements QuizService {
                             .text(optionRequest.text())
                             .detailText(optionRequest.detailText())
                             .isCorrect(optionRequest.isCorrect())
+                            .displayOrder(displayOrder)
                             .build();
                     option = quizOptionRepository.save(option);
                 } else {
                     option.update(
                             optionRequest.text(),
                             optionRequest.detailText(),
-                            optionRequest.isCorrect()
+                            optionRequest.isCorrect(),
+                            displayOrder
                     );
                 }
             }
@@ -169,6 +176,13 @@ public class QuizServiceImpl implements QuizService {
         quizOptionRepository.deleteAll(options);
         quizRepository.delete(quiz);
         return new AdminQuizDeleteResponse(true, LocalDateTime.now());
+    }
+
+    private int resolveDisplayOrder(Integer requestedOrder, int fallbackOrder) {
+        if (requestedOrder == null || requestedOrder < 1) {
+            return fallbackOrder;
+        }
+        return requestedOrder;
     }
 
     private void ensureTodayPicks(LocalDate today, int requiredCount) {

--- a/src/main/java/com/swyp/picke/domain/scenario/service/ScenarioServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/scenario/service/ScenarioServiceImpl.java
@@ -139,6 +139,11 @@ public class ScenarioServiceImpl implements ScenarioService {
                 if (mergedAudioUrl != null) s3Service.deleteFile(mergedAudioUrl);
             }
             scenario.clearAudios();
+
+            // 발행 상태에서 시나리오가 변경되면 merged 오디오를 다시 생성한다.
+            if (scenario.getStatus() == ScenarioStatus.PUBLISHED) {
+                triggerAudioPipeline(scenarioId);
+            }
         }
     }
 
@@ -259,12 +264,17 @@ public class ScenarioServiceImpl implements ScenarioService {
     }
 
     private void triggerAudioPipeline(Long scenarioId) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                audioPipelineService.generateAndMergeAudioAsync(scenarioId);
-            }
-        });
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    audioPipelineService.generateAndMergeAudioAsync(scenarioId);
+                }
+            });
+            return;
+        }
+
+        audioPipelineService.generateAndMergeAudioAsync(scenarioId);
     }
 
     private boolean updateScriptsSmartly(ScenarioNode existingNode, java.util.List<ScriptRequest> requestedScripts, Map<String, String> speakerMap) {

--- a/src/main/resources/static/js/admin/api/api-save.js
+++ b/src/main/resources/static/js/admin/api/api-save.js
@@ -26,6 +26,11 @@
         return Number.isNaN(parsed) ? null : parsed;
     };
 
+    const setHiddenImageValue = (id, value) => {
+        const input = document.getElementById(id);
+        if (input) input.value = value || '';
+    };
+
     const getTargetDate = (type) => {
         const inputIdByType = {
             BATTLE: 'battle-target-date',
@@ -52,7 +57,9 @@
         const previousStatus = PickeData.currentStatus;
         const targetDate = getTargetDate(currentType);
         const resolvedStatus = getStatus(currentType);
-        const shouldUploadAssets = action === 'PUBLISHED' || action === 'PUBLISH';
+        const hasNewBattleImageUploads = currentType === 'BATTLE'
+            && !!(PickeData.uploadedFiles.thumbnail || PickeData.uploadedFiles.charA || PickeData.uploadedFiles.charB);
+        const shouldUploadAssets = action === 'PUBLISHED' || action === 'PUBLISH' || (action === 'EDIT' && hasNewBattleImageUploads);
         const shouldUploadLocalDraft = action === 'PENDING';
 
         PickeData.currentTargetDate = targetDate;
@@ -83,6 +90,14 @@
         thumbnailUrl = toUrlString(thumbnailUrl);
         charAUrl = toUrlString(charAUrl);
         charBUrl = toUrlString(charBUrl);
+
+        PickeData.existingUrls.thumbnail = thumbnailUrl || null;
+        PickeData.existingUrls.charA = charAUrl || null;
+        PickeData.existingUrls.charB = charBUrl || null;
+
+        setHiddenImageValue('battle-thumbnail-url', thumbnailUrl);
+        setHiddenImageValue('char-a-image-url', charAUrl);
+        setHiddenImageValue('char-b-image-url', charBUrl);
 
         let payload = null;
         let requestUrl = '';
@@ -283,7 +298,10 @@
             }
 
             if (scenarioExisted && PickeData.scenarioId) {
-                const shouldPatchScenarioStatus = action === 'PUBLISH' || previousStatus !== resolvedStatus;
+                const shouldPatchScenarioStatus =
+                    action === 'PUBLISHED'
+                    || action === 'PUBLISH'
+                    || previousStatus !== resolvedStatus;
                 if (shouldPatchScenarioStatus) {
                     const statusRes = await fetch(`/api/v1/admin/scenarios/${PickeData.scenarioId}`, {
                         method: 'PATCH',

--- a/src/main/resources/templates/admin/components/form-battle.html
+++ b/src/main/resources/templates/admin/components/form-battle.html
@@ -39,6 +39,12 @@
                     </div>
                     <input id="thumbnail-upload" type="file" class="hidden" accept="image/*" />
                 </label>
+                <input id="battle-thumbnail-url" type="hidden" />
+            </div>
+
+            <div>
+                <label class="block text-sm font-bold text-gray-700 mb-2">타겟 날짜 <span class="text-red-500">*</span></label>
+                <input id="battle-target-date" type="date" class="w-full bg-gray-50 border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-black transition-all" />
             </div>
         </div>
     </section>
@@ -63,6 +69,7 @@
                     <span id="char-a-img-placeholder" class="text-xs font-bold text-gray-400 z-10">A 철학자 이미지</span>
                     <input type="file" id="char-a-img-upload" class="hidden" accept="image/*" />
                 </label>
+                <input id="char-a-image-url" type="hidden" />
 
                 <label class="block text-[11px] font-bold text-gray-500">철학자 태그</label>
                 <div class="flex flex-wrap gap-2 items-center bg-white p-2 border border-gray-100 rounded-lg min-h-[42px]" id="battle-a-philosopher-tags-container">
@@ -86,6 +93,7 @@
                     <span id="char-b-img-placeholder" class="text-xs font-bold text-gray-400 z-10">B 철학자 이미지</span>
                     <input type="file" id="char-b-img-upload" class="hidden" accept="image/*" />
                 </label>
+                <input id="char-b-image-url" type="hidden" />
 
                 <label class="block text-[11px] font-bold text-gray-500">철학자 태그</label>
                 <div class="flex flex-wrap gap-2 items-center bg-white p-2 border border-gray-100 rounded-lg min-h-[42px]" id="battle-b-philosopher-tags-container">

--- a/src/main/resources/templates/admin/components/form-quiz.html
+++ b/src/main/resources/templates/admin/components/form-quiz.html
@@ -11,6 +11,11 @@
                 <input type="text" id="quiz-title" name="title" placeholder="퀴즈 제목을 입력하세요" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition placeholder:text-gray-400" />
             </div>
 
+            <div>
+                <label class="block text-[13px] font-bold text-gray-700 mb-2">타겟 날짜 <span class="text-red-500 ml-0.5">*</span></label>
+                <input type="date" id="quiz-target-date" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition" />
+            </div>
+
             <hr class="border-gray-100 my-8">
 
             <div>
@@ -52,3 +57,4 @@
         </div>
     </section>
 </div>
+

--- a/src/main/resources/templates/admin/components/form-vote.html
+++ b/src/main/resources/templates/admin/components/form-vote.html
@@ -16,6 +16,11 @@
                 <input type="text" id="poll-title-suffix" name="titleSuffix" placeholder=" 하는 행위이다." class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition placeholder:text-gray-400">
             </div>
 
+            <div>
+                <label class="block text-[13px] font-bold text-gray-700 mb-2">타겟 날짜 <span class="text-red-500 ml-0.5">*</span></label>
+                <input type="date" id="poll-target-date" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition" />
+            </div>
+
             <hr class="border-gray-100 my-8">
 
             <div>
@@ -49,3 +54,4 @@
         </div>
     </section>
 </div>
+

--- a/src/test/java/com/swyp/picke/domain/admin/controller/AdminContentCreationIntegrationTest.java
+++ b/src/test/java/com/swyp/picke/domain/admin/controller/AdminContentCreationIntegrationTest.java
@@ -96,6 +96,7 @@ class AdminContentCreationIntegrationTest {
     void createBattle_persistsAllMappedFields() throws Exception {
         User admin = createAdminUser();
         String adminToken = jwtProvider.createAccessToken(admin.getId(), "ADMIN");
+        LocalDate targetDate = LocalDate.now();
 
         Tag category = createTag("battle-category", TagType.CATEGORY);
         Tag philosopher = createTag("battle-philosopher", TagType.PHILOSOPHER);
@@ -108,7 +109,7 @@ class AdminContentCreationIntegrationTest {
                 "summary", "배틀 요약",
                 "description", "배틀 설명",
                 "thumbnailUrl", "images/battles/battle-thumb.png",
-                "targetDate", LocalDate.now().toString(),
+                "targetDate", targetDate.toString(),
                 "audioDuration", 95,
                 "tagIds", List.of(category.getId()),
                 "options", List.of(
@@ -151,8 +152,8 @@ class AdminContentCreationIntegrationTest {
         assertThat(savedBattle.getSummary()).isEqualTo("배틀 요약");
         assertThat(savedBattle.getDescription()).isEqualTo("배틀 설명");
         assertThat(savedBattle.getThumbnailUrl()).isEqualTo("images/battles/battle-thumb.png");
-        assertThat(savedBattle.getAudioDuration()).isNull();
-        assertThat(savedBattle.getTargetDate()).isNull();
+        assertThat(savedBattle.getAudioDuration()).isEqualTo(95);
+        assertThat(savedBattle.getTargetDate()).isEqualTo(targetDate);
 
         assertThat(options).hasSize(2);
         BattleOption optionA = options.stream().filter(option -> option.getLabel().name().equals("A")).findFirst().orElseThrow();
@@ -171,14 +172,15 @@ class AdminContentCreationIntegrationTest {
     }
 
     @Test
-    @DisplayName("관리자가 퀴즈를 생성할 때 현재 500을 반환한다")
+    @DisplayName("관리자가 퀴즈를 생성할 때 필드가 저장된다")
     void createQuiz_persistsAllMappedFields() throws Exception {
         User admin = createAdminUser();
         String adminToken = jwtProvider.createAccessToken(admin.getId(), "ADMIN");
+        LocalDate targetDate = LocalDate.now().plusDays(1);
 
         Map<String, Object> payload = Map.of(
                 "title", "퀴즈 제목",
-                "targetDate", LocalDate.now().plusDays(1).toString(),
+                "targetDate", targetDate.toString(),
                 "status", "PENDING",
                 "options", List.of(
                         Map.of(
@@ -202,20 +204,24 @@ class AdminContentCreationIntegrationTest {
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(payload)))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.statusCode").value(500));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.quizId").exists())
+                .andExpect(jsonPath("$.data.targetDate").value(targetDate.toString()))
+                .andExpect(jsonPath("$.data.options[0].displayOrder").value(1))
+                .andExpect(jsonPath("$.data.options[1].displayOrder").value(2));
     }
 
     @Test
-    @DisplayName("관리자가 투표를 생성할 때 현재 500을 반환한다")
+    @DisplayName("관리자가 투표를 생성할 때 필드가 저장된다")
     void createPoll_persistsAllMappedFields() throws Exception {
         User admin = createAdminUser();
         String adminToken = jwtProvider.createAccessToken(admin.getId(), "ADMIN");
+        LocalDate targetDate = LocalDate.now().plusDays(2);
 
         Map<String, Object> payload = Map.of(
                 "titlePrefix", "당신은",
                 "titleSuffix", "어느 쪽인가요?",
-                "targetDate", LocalDate.now().plusDays(2).toString(),
+                "targetDate", targetDate.toString(),
                 "status", "PENDING",
                 "options", List.of(
                         Map.of(
@@ -235,8 +241,11 @@ class AdminContentCreationIntegrationTest {
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(payload)))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.statusCode").value(500));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.pollId").exists())
+                .andExpect(jsonPath("$.data.targetDate").value(targetDate.toString()))
+                .andExpect(jsonPath("$.data.options[0].displayOrder").value(1))
+                .andExpect(jsonPath("$.data.options[1].displayOrder").value(2));
     }
 
     @Test

--- a/src/test/java/com/swyp/picke/domain/scenario/service/ScenarioServiceImplTest.java
+++ b/src/test/java/com/swyp/picke/domain/scenario/service/ScenarioServiceImplTest.java
@@ -161,6 +161,43 @@ class ScenarioServiceImplTest {
         verify(s3Service).deleteFile("s3://merged/common-old.mp3");
     }
 
+    @Test
+    void updateScenarioContent_whenPublishedAndModified_triggersAudioPipeline() {
+        Scenario scenario = createScenario();
+        scenario.updateStatus(ScenarioStatus.PUBLISHED);
+        ScenarioNode startNode = createNode("START", true);
+        Script script = createScript(SpeakerType.NARRATOR, "NARRATOR", "old-line", "s3://chunks/script-old.mp3");
+        startNode.addScript(script);
+        scenario.addNode(startNode);
+        scenario.addAudioUrl(AudioPathType.COMMON, "s3://merged/common-old.mp3");
+        scenario.replaceVoiceSettings(Map.of(SpeakerType.NARRATOR, "voice-narrator"));
+
+        when(scenarioRepository.findById(3L)).thenReturn(Optional.of(scenario));
+        when(battleOptionRepository.findByBattle(scenario.getBattle())).thenReturn(List.of());
+
+        ScenarioCreateRequest request = new ScenarioCreateRequest(
+                1L,
+                false,
+                ScenarioStatus.PUBLISHED,
+                List.of(
+                        new NodeRequest(
+                                "START",
+                                true,
+                                "",
+                                List.of(new ScriptRequest("NARRATOR", SpeakerType.NARRATOR, "new-line")),
+                                List.of()
+                        )
+                ),
+                Map.of(SpeakerType.NARRATOR, "voice-narrator")
+        );
+
+        scenarioService.updateScenarioContent(3L, request);
+
+        verify(s3Service).deleteFile("s3://chunks/script-old.mp3");
+        verify(s3Service).deleteFile("s3://merged/common-old.mp3");
+        verify(audioPipelineService).generateAndMergeAudioAsync(3L);
+    }
+
     private Scenario createScenario() {
         Battle battle = Battle.builder()
                 .title("battle")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #191

## 📌 공유 사항
1. 관리자 생성 화면에서 `배틀/퀴즈/투표` 모두 `targetDate` 입력이 가능하도록 UI를 통일했습니다.
2. 저장 payload와 백엔드 DTO/서비스 매핑을 정리해 `targetDate`가 실제 DB까지 반영되도록 수정했습니다.
3. 퀴즈/투표 옵션 저장 시 `displayOrder`/`isCorrect` 경로를 점검하고 저장 안정성을 보강했습니다.
4. 발행 상태 시나리오 수정 시 merged 오디오가 재생성되도록 오디오 파이프라인 트리거를 보완했습니다.

## ✅ 체크리스트
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 오늘의 Picke 노출 조건(`targetDate=오늘`, `PUBLISHED`)을 코드 기준으로 확인했나요?

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| Battle create/update에 `targetDate`, `audioDuration` 저장 매핑 반영 | `AdminBattleCreateRequest.java`, `AdminBattleUpdateRequest.java`, `Battle.java`, `BattleServiceImpl.java`, `BattleConverter.java` |
| Quiz/Poll create 경로에 `targetDate` 매핑 반영 | `AdminQuizCreateRequest.java`, `AdminPollCreateRequest.java`, `QuizConverter.java`, `PollConverter.java` |
| Quiz/Poll 옵션 `displayOrder` 저장/업데이트 보완 | `AdminQuizOptionRequest.java`, `AdminPollOptionRequest.java`, `QuizOption.java`, `PollOption.java`, `QuizServiceImpl.java`, `PollServiceImpl.java` |
| 관리자 UI에 `quiz-target-date`, `poll-target-date`, `battle-target-date` 입력 추가 | `form-quiz.html`, `form-vote.html`, `form-battle.html` |
| 관리자 저장 스크립트에서 targetDate/이미지 hidden 값/EDIT 업로드 조건 보완 | `api-save.js` |
| 발행 상태 시나리오 수정 시 오디오 재합성 트리거 추가 | `ScenarioServiceImpl.java` |
| 통합/단위 테스트 보강 및 회귀 검증 | `AdminContentCreationIntegrationTest.java`, `ScenarioServiceImplTest.java` |

## 🧪 검증
- `./gradlew.bat compileJava`
- `./gradlew.bat test --tests "com.swyp.picke.domain.admin.controller.AdminContentCreationIntegrationTest" --tests "com.swyp.picke.domain.home.service.HomeServiceTest" --tests "com.swyp.picke.domain.scenario.service.ScenarioServiceImplTest"`

## 💬 리뷰 요구사항
> 관리자 생성/수정에서 `targetDate`가 타입별로 일관되게 저장되는지, 그리고 발행 후 시나리오 수정 시 오디오 재합성 동작이 의도대로인지 확인 부탁드립니다.

Closes #191