### PR TITLE
#211 [Fix] 흥미로운 배틀 API tags 빈 배열 수정

### DIFF
--- a/src/main/java/com/swyp/picke/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/swyp/picke/domain/recommendation/service/RecommendationService.java
@@ -2,10 +2,11 @@ package com.swyp.picke.domain.recommendation.service;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.entity.BattleOptionTag;
+import com.swyp.picke.domain.battle.entity.BattleTag;
 import com.swyp.picke.domain.battle.repository.BattleOptionRepository;
 import com.swyp.picke.domain.battle.repository.BattleOptionTagRepository;
 import com.swyp.picke.domain.battle.repository.BattleRepository;
+import com.swyp.picke.domain.battle.repository.BattleTagRepository;
 import com.swyp.picke.domain.battle.service.BattleService;
 import com.swyp.picke.domain.recommendation.dto.response.RecommendationListResponse;
 import com.swyp.picke.domain.tag.enums.TagType;
@@ -35,6 +36,7 @@ public class RecommendationService {
     private final BattleRepository battleRepository;
     private final BattleOptionRepository battleOptionRepository;
     private final BattleOptionTagRepository battleOptionTagRepository;
+    private final BattleTagRepository battleTagRepository;
     private final BattleVoteRepository BattleVoteRepository;
     private final UserService userService;
     private final ResourceUrlProvider urlProvider;
@@ -101,12 +103,9 @@ public class RecommendationService {
                 ))
                 .toList();
 
-        // CATEGORY 태그만 노출
-        List<RecommendationListResponse.TagSummary> tagSummaries = options.stream()
-                .flatMap(opt -> battleOptionTagRepository.findByBattleOption(opt).stream())
-                .map(BattleOptionTag::getTag)
+        List<RecommendationListResponse.TagSummary> tagSummaries = battleTagRepository.findByBattle(battle).stream()
+                .map(BattleTag::getTag)
                 .filter(tag -> tag.getType() == TagType.CATEGORY)
-                .distinct()
                 .map(tag -> new RecommendationListResponse.TagSummary(tag.getId(), tag.getName()))
                 .toList();
 


### PR DESCRIPTION
 ## #️ 연관된 이슈            
  - #211
                                                                                                                                                                                      ## 📝 작업 내용
                                                                                                                                                                                    
  ### 🐛 Fix                                                                                                                                                                        
  | 내용 | 파일 |
  |------|------|
  | 흥미로운 배틀 API `tags` 항상 빈 배열로 반환되는 버그 수정 — `battle_option_tags` 대신 `battle_tags`에서 CATEGORY 태그 조회하도록 변경 | `RecommendationService.java` |

  ## 📌 공유 사항
  > 1. 기존 코드가 옵션 태그 테이블(`battle_option_tags`)에서 CATEGORY 태그를 찾고 있었으나, CATEGORY 태그는 배틀 태그 테이블(`battle_tags`)에 저장됩니다. 일부 구버전 배틀
  데이터에는 옵션에 CATEGORY 태그가 잘못 저장된 케이스가 있어 간헐적으로 정상 동작하는 것처럼 보였습니다.

  ## ✅ 체크리스트
  - [x] Reviewer에 팀원들을 선택했나요?
  - [x] Assignees에 본인을 선택했나요?
  - [x] 컨벤션에 맞는 Type을 선택했나요?
  - [x] Development에 이슈를 연동했나요?
  - [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [x] 컨벤션을 지키고 있나요?
  - [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [x] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷

  ## 💬 리뷰 요구사항
  > 1. 없음