### PR TITLE
#212 [Fix] 알림 노출 기준(user_id) 정리 및 관리자 공지 저장 플로우 검증 보강

### DIFF
--- a/src/main/java/com/swyp/picke/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/swyp/picke/domain/notification/repository/NotificationRepository.java
@@ -14,9 +14,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("""
             SELECT n FROM Notification n
             WHERE (
-                (n.category = com.swyp.picke.domain.notification.enums.NotificationCategory.CONTENT AND n.user.id = :userId)
-                OR
-                (n.category <> com.swyp.picke.domain.notification.enums.NotificationCategory.CONTENT AND n.user IS NULL)
+                (n.user IS NOT NULL AND n.user.id = :userId)
+                OR n.user IS NULL
             )
             AND (:category IS NULL OR n.category = :category)
             ORDER BY n.createdAt DESC

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationService.java
@@ -80,7 +80,7 @@ public class NotificationService {
                 userId, filterCategory, PageRequest.of(page, pageSize));
 
         List<Long> broadcastIds = slice.getContent().stream()
-                .filter(n -> n.getCategory() != NotificationCategory.CONTENT)
+                .filter(n -> n.getUser() == null)
                 .map(Notification::getId)
                 .toList();
 
@@ -102,7 +102,7 @@ public class NotificationService {
     public NotificationDetailResponse getNotificationDetail(Long userId, Long notificationId) {
         Notification notification = getAccessibleNotification(userId, notificationId);
 
-        if (notification.getCategory() == NotificationCategory.CONTENT) {
+        if (notification.getUser() != null) {
             return toDetailResponse(notification, notification.isRead(), notification.getReadAt());
         }
 
@@ -114,7 +114,7 @@ public class NotificationService {
     public void markAsRead(Long userId, Long notificationId) {
         Notification notification = getAccessibleNotification(userId, notificationId);
 
-        if (notification.getCategory() == NotificationCategory.CONTENT) {
+        if (notification.getUser() != null) {
             notification.markAsRead();
             return;
         }
@@ -144,9 +144,8 @@ public class NotificationService {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
-        boolean isAccessible = notification.getCategory() == NotificationCategory.CONTENT
-                ? notification.getUser() != null && notification.getUser().getId().equals(userId)
-                : notification.getUser() == null;
+        boolean isAccessible = notification.getUser() == null
+                || notification.getUser().getId().equals(userId);
 
         if (!isAccessible) {
             throw new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND);
@@ -156,10 +155,9 @@ public class NotificationService {
     }
 
     private boolean resolveIsRead(Notification notification, Set<Long> readBroadcastIds) {
-        if (notification.getCategory() == NotificationCategory.CONTENT) {
-            return notification.isRead();
-        }
-        return readBroadcastIds.contains(notification.getId());
+        return notification.getUser() != null
+                ? notification.isRead()
+                : readBroadcastIds.contains(notification.getId());
     }
 
     private NotificationDetailResponse toDetailResponse(Notification notification, boolean isRead, java.time.LocalDateTime readAt) {

--- a/src/test/java/com/swyp/picke/domain/admin/controller/AdminNoticeIntegrationTest.java
+++ b/src/test/java/com/swyp/picke/domain/admin/controller/AdminNoticeIntegrationTest.java
@@ -3,6 +3,7 @@ package com.swyp.picke.domain.admin.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp.picke.domain.notification.entity.Notification;
 import com.swyp.picke.domain.notification.enums.NotificationCategory;
+import com.swyp.picke.domain.notification.enums.NotificationDetailCode;
 import com.swyp.picke.domain.notification.repository.NotificationRepository;
 import com.swyp.picke.domain.oauth.jwt.JwtProvider;
 import com.swyp.picke.domain.user.entity.User;
@@ -25,6 +26,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -57,15 +61,15 @@ class AdminNoticeIntegrationTest {
     private S3PresignedUrlService s3PresignedUrlService;
 
     @Test
-    @DisplayName("관리자 공지 생성 및 목록 조회가 동작한다")
+    @DisplayName("admin can create and list notices")
     void admin_can_create_and_list_notices() throws Exception {
         String adminToken = createAdminToken();
+        String title = "notice-" + UUID.randomUUID().toString().substring(0, 8);
 
         Map<String, Object> payload = Map.of(
                 "category", "NOTICE",
-                "title", "서비스 점검 안내",
-                "body", "오늘 22시에 점검이 진행됩니다.",
-                "referenceId", 123L
+                "title", title,
+                "body", "maintenance at 22:00"
         );
 
         mockMvc.perform(post("/api/v1/admin/notices")
@@ -75,10 +79,10 @@ class AdminNoticeIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.notificationId").exists())
                 .andExpect(jsonPath("$.data.category").value("NOTICE"))
-                .andExpect(jsonPath("$.data.title").value("서비스 점검 안내"));
+                .andExpect(jsonPath("$.data.title").value(title));
 
         Notification saved = notificationRepository.findAll().stream()
-                .filter(notification -> "서비스 점검 안내".equals(notification.getTitle()))
+                .filter(notification -> title.equals(notification.getTitle()))
                 .findFirst()
                 .orElseThrow();
 
@@ -90,19 +94,195 @@ class AdminNoticeIntegrationTest {
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.items[0].notificationId").exists())
-                .andExpect(jsonPath("$.data.items[0].title").isNotEmpty());
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(title)));
+    }
+
+    @Test
+    @DisplayName("admin notice page form flow persists notice and user can fetch it")
+    void admin_notice_page_form_flow_persists_notice_and_user_can_fetch_it() throws Exception {
+        String adminToken = createAdminToken();
+        String userToken = createUserToken();
+        String marker = UUID.randomUUID().toString().substring(0, 8);
+        String title = "ui-notice-" + marker;
+        String body = "ui-body-" + marker;
+
+        mockMvc.perform(get("/api/v1/admin/picke/notice"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("id=\"notice-form\"")))
+                .andExpect(content().string(containsString("id=\"notice-title\"")))
+                .andExpect(content().string(containsString("id=\"notice-body\"")))
+                .andExpect(content().string(containsString("/js/admin/notice/notice.js")));
+
+        Map<String, Object> payload = Map.of(
+                "category", "NOTICE",
+                "title", title,
+                "body", body
+        );
+
+        String createResponse = mockMvc.perform(post("/api/v1/admin/notices")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.category").value("NOTICE"))
+                .andExpect(jsonPath("$.data.title").value(title))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        long noticeId = objectMapper.readTree(createResponse)
+                .path("data")
+                .path("notificationId")
+                .asLong();
+
+        assertThat(noticeId).isPositive();
+
+        Notification saved = notificationRepository.findById(noticeId).orElseThrow();
+        assertThat(saved.getTitle()).isEqualTo(title);
+        assertThat(saved.getBody()).isEqualTo(body);
+        assertThat(saved.getCategory()).isEqualTo(NotificationCategory.NOTICE);
+        assertThat(saved.getUser()).isNull();
+
+        mockMvc.perform(get("/api/v1/admin/notices")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .param("category", "NOTICE")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(title)));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .header("Authorization", "Bearer " + userToken)
+                        .param("category", "NOTICE")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(title)));
+
+        mockMvc.perform(get("/api/v1/notifications/{notificationId}", noticeId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notificationId").value((int) noticeId))
+                .andExpect(jsonPath("$.data.title").value(title))
+                .andExpect(jsonPath("$.data.body").value(body))
+                .andExpect(jsonPath("$.data.category").value("NOTICE"));
+    }
+
+    @Test
+    @DisplayName("admin registration creates CONTENT NOTICE EVENT broadcasts and user can list/detail them")
+    void admin_registration_creates_all_categories_and_user_can_fetch_list_and_detail() throws Exception {
+        String adminToken = createAdminToken();
+        String userToken = createUserToken();
+        String marker = UUID.randomUUID().toString().substring(0, 8);
+
+        String contentTitle = "content-" + marker;
+        String noticeTitle = "notice-" + marker;
+        String eventTitle = "event-" + marker;
+
+        Notification content = assertCategoryFlow(
+                adminToken, userToken, NotificationCategory.CONTENT, contentTitle, NotificationDetailCode.NEW_BATTLE);
+        Notification notice = assertCategoryFlow(
+                adminToken, userToken, NotificationCategory.NOTICE, noticeTitle, NotificationDetailCode.POLICY_CHANGE);
+        Notification event = assertCategoryFlow(
+                adminToken, userToken, NotificationCategory.EVENT, eventTitle, NotificationDetailCode.PROMOTION);
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .header("Authorization", "Bearer " + userToken)
+                        .param("category", "ALL")
+                        .param("page", "0")
+                        .param("size", "50"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(contentTitle)))
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(noticeTitle)))
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(eventTitle)));
+
+        mockMvc.perform(get("/api/v1/notifications/{notificationId}", content.getId())
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notificationId").value(content.getId().intValue()))
+                .andExpect(jsonPath("$.data.category").value("CONTENT"));
+
+        mockMvc.perform(get("/api/v1/notifications/{notificationId}", notice.getId())
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notificationId").value(notice.getId().intValue()))
+                .andExpect(jsonPath("$.data.category").value("NOTICE"));
+
+        mockMvc.perform(get("/api/v1/notifications/{notificationId}", event.getId())
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notificationId").value(event.getId().intValue()))
+                .andExpect(jsonPath("$.data.category").value("EVENT"));
+    }
+
+    private Notification assertCategoryFlow(
+            String adminToken,
+            String userToken,
+            NotificationCategory category,
+            String title,
+            NotificationDetailCode expectedDetailCode
+    ) throws Exception {
+        String body = "body-" + category.name();
+        Map<String, Object> payload = Map.of(
+                "category", category.name(),
+                "title", title,
+                "body", body
+        );
+
+        mockMvc.perform(post("/api/v1/admin/notices")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.category").value(category.name()))
+                .andExpect(jsonPath("$.data.title").value(title));
+
+        Notification saved = notificationRepository.findAll().stream()
+                .filter(notification -> title.equals(notification.getTitle()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(saved.getUser()).isNull();
+        assertThat(saved.getCategory()).isEqualTo(category);
+        assertThat(saved.getDetailCode()).isEqualTo(expectedDetailCode);
+        assertThat(saved.getBody()).isEqualTo(body);
+
+        mockMvc.perform(get("/api/v1/admin/notices")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .param("category", category.name())
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(title)));
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .header("Authorization", "Bearer " + userToken)
+                        .param("category", category.name())
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[*].title", hasItem(title)));
+
+        return saved;
     }
 
     private String createAdminToken() {
-        User admin = userRepository.save(
+        return createToken(UserRole.ADMIN, "adm");
+    }
+
+    private String createUserToken() {
+        return createToken(UserRole.USER, "usr");
+    }
+
+    private String createToken(UserRole role, String prefix) {
+        User user = userRepository.save(
                 User.builder()
-                        .userTag("adm-" + UUID.randomUUID().toString().substring(0, 8))
-                        .nickname("admin")
-                        .role(UserRole.ADMIN)
+                        .userTag(prefix + "-" + UUID.randomUUID().toString().substring(0, 8))
+                        .nickname(prefix)
+                        .role(role)
                         .status(UserStatus.ACTIVE)
                         .build()
         );
-        return jwtProvider.createAccessToken(admin.getId(), "ADMIN");
+        return jwtProvider.createAccessToken(user.getId(), role.name());
     }
 }

--- a/src/test/java/com/swyp/picke/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/notification/service/NotificationServiceTest.java
@@ -135,6 +135,33 @@ class NotificationServiceTest {
     }
 
     @Test
+    @DisplayName("content broadcast is visible to users")
+    void getNotifications_includes_content_broadcast_notifications() {
+        Long userId = 1L;
+        Notification broadcastContent = Notification.builder()
+                .user(null)
+                .category(NotificationCategory.CONTENT)
+                .detailCode(NotificationDetailCode.NEW_BATTLE)
+                .title("New content")
+                .body("Broadcast content notification")
+                .referenceId(77L)
+                .build();
+
+        setNotificationId(broadcastContent, 77L);
+
+        when(notificationRepository.findVisibleNotifications(eq(userId), eq(NotificationCategory.CONTENT), any(Pageable.class)))
+                .thenReturn(new SliceImpl<>(List.of(broadcastContent)));
+        when(notificationReadRepository.findByUserIdAndNotificationIdIn(userId, List.of(77L)))
+                .thenReturn(List.of());
+
+        NotificationListResponse response = notificationService.getNotifications(userId, NotificationCategory.CONTENT, 0, 20);
+
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().getFirst().category()).isEqualTo(NotificationCategory.CONTENT);
+        assertThat(response.items().getFirst().isRead()).isFalse();
+    }
+
+    @Test
     @DisplayName("존재하지 않는 알림 읽음 처리 시 예외를 던진다")
     void markAsRead_throws_when_not_found() {
         when(notificationRepository.findById(999L)).thenReturn(Optional.empty());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #212

## 📝 작업 내용

### ♻️ Refactor
| 내용 | 파일 |
|------|------|
| 사용자 알림 가시성 판별 기준을 카테고리 분기에서 `user_id` 기준(전체:null / 개인:not null)으로 정리 | `NotificationRepository.java`, `NotificationService.java` |

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| 전체 공지 성격의 CONTENT 알림이 사용자 목록/상세에서 누락되지 않도록 조회/읽음 처리 로직 수정 | `NotificationService.java`, `NotificationRepository.java` |
| 관리자 공지 페이지 저장 플로우 검증(페이지 렌더링 요소 + 등록 + 관리자/사용자 조회) 통합 테스트 추가 | `AdminNoticeIntegrationTest.java` |
| CONTENT 브로드캐스트 알림 사용자 노출 회귀 테스트 추가 | `NotificationServiceTest.java` |

## 📌 공유 사항
> 1. 관리자 공지 등록 후 `user_id == null` 레코드는 CONTENT/NOTICE/EVENT 공통으로 사용자 조회 대상입니다.
> 2. 개인 대상 알림(`user_id != null`)은 기존처럼 해당 사용자만 조회/읽음 처리됩니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
- 테스트 실행: `./gradlew test --tests "com.swyp.picke.domain.admin.controller.AdminNoticeIntegrationTest" --tests "com.swyp.picke.domain.admin.controller.AdminContentCreationIntegrationTest" --tests "com.swyp.picke.domain.scenario.service.ScenarioServiceImplTest" --tests "com.swyp.picke.domain.admin.controller.AdminScenarioPublishFlowIntegrationTest"`
- 결과: `BUILD SUCCESSFUL`

## 💬 리뷰 요구사항
> 1. `CONTENT`를 포함한 전체 공지 알림을 `user_id` 기준으로 통일한 정책이 운영 의도와 일치하는지 확인 부탁드립니다.
> 2. 관리자 공지 페이지 저장 흐름 검증 수준(페이지 요소/저장/조회)이 추가로 보강되어야 할 지점이 있다면 의견 부탁드립니다.