### PR TITLE
#231 [Feat] 퀴즈·투표·배틀 예약 발행 시스템 추가

### DIFF
--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 배틀 API", description = "관리자 배틀 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/battles")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
@@ -6,6 +6,7 @@ import com.swyp.picke.domain.admin.dto.battle.response.AdminBattleDetailResponse
 import com.swyp.picke.domain.admin.dto.battle.request.AdminBattleUpdateRequest;
 import com.swyp.picke.domain.admin.service.AdminBattleService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 배틀 API", description = "관리자 배틀 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/battles")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminNotificationController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 공지 API", description = "공지사항/이벤트 작성 및 조회")
 @RestController
 @RequestMapping("/api/v1/admin/notices")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminNotificationController.java
@@ -6,6 +6,7 @@ import com.swyp.picke.domain.admin.dto.notification.response.AdminNoticeListResp
 import com.swyp.picke.domain.admin.service.AdminNotificationService;
 import com.swyp.picke.domain.notification.enums.NotificationCategory;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 공지 API", description = "공지사항/이벤트 작성 및 조회")
 @RestController
 @RequestMapping("/api/v1/admin/notices")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminPollController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminPollController.java
@@ -6,6 +6,7 @@ import com.swyp.picke.domain.admin.dto.poll.response.AdminPollDeleteResponse;
 import com.swyp.picke.domain.admin.dto.poll.response.AdminPollDetailResponse;
 import com.swyp.picke.domain.admin.service.AdminPollService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 투표 콘텐츠 API", description = "관리자 투표 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/polls")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminPollController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminPollController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 투표 콘텐츠 API", description = "관리자 투표 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/polls")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminQuizController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminQuizController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 퀴즈 API", description = "관리자 퀴즈 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/quizzes")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminQuizController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminQuizController.java
@@ -6,6 +6,7 @@ import com.swyp.picke.domain.admin.dto.quiz.response.AdminQuizDeleteResponse;
 import com.swyp.picke.domain.admin.dto.quiz.response.AdminQuizDetailResponse;
 import com.swyp.picke.domain.admin.service.AdminQuizService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 퀴즈 API", description = "관리자 퀴즈 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/quizzes")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminScenarioController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminScenarioController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 시나리오 API", description = "관리자 시나리오 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminScenarioController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminScenarioController.java
@@ -8,6 +8,7 @@ import com.swyp.picke.domain.admin.dto.scenario.response.AdminScenarioDetailResp
 import com.swyp.picke.domain.admin.dto.scenario.response.AdminScenarioResponse;
 import com.swyp.picke.domain.admin.service.AdminScenarioService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 시나리오 API", description = "관리자 시나리오 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminTagController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminTagController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 태그 API", description = "관리자 태그 생성, 수정, 삭제")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminTagController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminTagController.java
@@ -5,6 +5,7 @@ import com.swyp.picke.domain.admin.dto.tag.response.TagDeleteResponse;
 import com.swyp.picke.domain.admin.dto.tag.response.TagResponse;
 import com.swyp.picke.domain.admin.service.AdminTagService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 태그 API", description = "관리자 태그 생성, 수정, 삭제")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleCreateRequest.java
@@ -2,6 +2,7 @@ package com.swyp.picke.domain.admin.dto.battle.request;
 
 import com.swyp.picke.domain.battle.enums.BattleStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminBattleCreateRequest(
@@ -10,6 +11,7 @@ public record AdminBattleCreateRequest(
         String description,
         String thumbnailUrl,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         Integer audioDuration,
         BattleStatus status,
         List<Long> tagIds,

--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleUpdateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleUpdateRequest.java
@@ -2,6 +2,7 @@ package com.swyp.picke.domain.admin.dto.battle.request;
 
 import com.swyp.picke.domain.battle.enums.BattleStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminBattleUpdateRequest(
@@ -10,6 +11,7 @@ public record AdminBattleUpdateRequest(
         String description,
         String thumbnailUrl,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         Integer audioDuration,
         BattleStatus status,
         List<Long> tagIds,

--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/response/AdminBattleDetailResponse.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/response/AdminBattleDetailResponse.java
@@ -20,6 +20,7 @@ public record AdminBattleDetailResponse(
         String thumbnailUrl,
         Integer audioDuration,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         BattleStatus status,
         BattleCreatorType creatorType,
         List<BattleTagResponse> tags,

--- a/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollCreateRequest.java
@@ -2,12 +2,14 @@ package com.swyp.picke.domain.admin.dto.poll.request;
 
 import com.swyp.picke.domain.poll.enums.PollStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminPollCreateRequest(
         String titlePrefix,
         String titleSuffix,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         PollStatus status,
         List<AdminPollOptionRequest> options
 ) {

--- a/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollUpdateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollUpdateRequest.java
@@ -3,12 +3,14 @@ package com.swyp.picke.domain.admin.dto.poll.request;
 import com.swyp.picke.domain.poll.enums.PollStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminPollUpdateRequest(
         String titlePrefix,
         String titleSuffix,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         PollStatus status,
         List<AdminPollOptionRequest> options
 ) {

--- a/src/main/java/com/swyp/picke/domain/admin/dto/poll/response/AdminPollDetailResponse.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/poll/response/AdminPollDetailResponse.java
@@ -4,6 +4,7 @@ import com.swyp.picke.domain.poll.dto.response.PollOptionResponse;
 import com.swyp.picke.domain.poll.enums.PollStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminPollDetailResponse(
@@ -11,6 +12,7 @@ public record AdminPollDetailResponse(
         String titlePrefix,
         String titleSuffix,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         PollStatus status,
         List<PollOptionResponse> options
 ) {}

--- a/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizCreateRequest.java
@@ -2,11 +2,13 @@ package com.swyp.picke.domain.admin.dto.quiz.request;
 
 import com.swyp.picke.domain.quiz.enums.QuizStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminQuizCreateRequest(
         String title,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         QuizStatus status,
         List<AdminQuizOptionRequest> options
 ) {}

--- a/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizUpdateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/quiz/request/AdminQuizUpdateRequest.java
@@ -3,11 +3,13 @@ package com.swyp.picke.domain.admin.dto.quiz.request;
 import com.swyp.picke.domain.quiz.enums.QuizStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminQuizUpdateRequest(
         String title,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         QuizStatus status,
         List<AdminQuizOptionRequest> options
 ) {

--- a/src/main/java/com/swyp/picke/domain/admin/dto/quiz/response/AdminQuizDetailResponse.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/quiz/response/AdminQuizDetailResponse.java
@@ -4,12 +4,14 @@ import com.swyp.picke.domain.quiz.dto.response.QuizOptionResponse;
 import com.swyp.picke.domain.quiz.enums.QuizStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminQuizDetailResponse(
         Long quizId,
         String title,
         LocalDate targetDate,
+        LocalDateTime publishAt,
         QuizStatus status,
         List<QuizOptionResponse> options
 ) {}

--- a/src/main/java/com/swyp/picke/domain/admin/scheduler/ContentPublishScheduler.java
+++ b/src/main/java/com/swyp/picke/domain/admin/scheduler/ContentPublishScheduler.java
@@ -1,0 +1,42 @@
+package com.swyp.picke.domain.admin.scheduler;
+
+import com.swyp.picke.domain.battle.service.BattleService;
+import com.swyp.picke.domain.poll.service.PollService;
+import com.swyp.picke.domain.quiz.service.QuizService;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ContentPublishScheduler {
+
+    private static final String SEOUL_ZONE_ID = "Asia/Seoul";
+    private static final ZoneId SEOUL_ZONE = ZoneId.of(SEOUL_ZONE_ID);
+
+    private final BattleService battleService;
+    private final QuizService quizService;
+    private final PollService pollService;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = SEOUL_ZONE_ID)
+    public void openReadyBattles() {
+        LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
+        int openedCount = battleService.openReadyBattles(now);
+        log.info("배틀 예약 발행 스케줄러 완료. 공개건수={}, 실행시각={}", openedCount, now);
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = SEOUL_ZONE_ID)
+    public void openReadyQuizzesAndPolls() {
+        LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
+        int quizOpenedCount = quizService.openReadyQuizzes(now);
+        int pollOpenedCount = pollService.openReadyPolls(now);
+        log.info("퀴즈/투표 예약 발행 스케줄러 완료. 퀴즈공개건수={}, 투표공개건수={}, 실행시각={}",
+                quizOpenedCount,
+                pollOpenedCount,
+                now);
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/admin/service/AdminPollService.java
+++ b/src/main/java/com/swyp/picke/domain/admin/service/AdminPollService.java
@@ -31,6 +31,6 @@ public class AdminPollService {
     }
 
     public Object getPolls(int page, int size, String status) {
-        return pollService.getPolls(page, size);
+        return pollService.getPolls(page, size, status);
     }
 }

--- a/src/main/java/com/swyp/picke/domain/admin/service/AdminQuizService.java
+++ b/src/main/java/com/swyp/picke/domain/admin/service/AdminQuizService.java
@@ -31,6 +31,6 @@ public class AdminQuizService {
     }
 
     public Object getQuizzes(int page, int size, String status) {
-        return quizService.getQuizzes(page, size);
+        return quizService.getQuizzes(page, size, status);
     }
 }

--- a/src/main/java/com/swyp/picke/domain/battle/controller/AdminBattleProposalController.java
+++ b/src/main/java/com/swyp/picke/domain/battle/controller/AdminBattleProposalController.java
@@ -4,6 +4,7 @@ import com.swyp.picke.domain.battle.dto.response.BattleProposalResponse;
 import com.swyp.picke.domain.battle.dto.request.BattleProposalReviewRequest;
 import com.swyp.picke.domain.battle.service.BattleProposalService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -11,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "관리자 배틀 제안 API", description = "주제 제안 목록 조회 및 채택/미채택 처리")
 @RestController
 @RequestMapping("/api/v1/admin/battles")

--- a/src/main/java/com/swyp/picke/domain/battle/controller/AdminBattleProposalController.java
+++ b/src/main/java/com/swyp/picke/domain/battle/controller/AdminBattleProposalController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "관리자 배틀 제안 API", description = "주제 제안 목록 조회 및 채택/미채택 처리")
 @RestController
 @RequestMapping("/api/v1/admin/battles")

--- a/src/main/java/com/swyp/picke/domain/battle/controller/BattleController.java
+++ b/src/main/java/com/swyp/picke/domain/battle/controller/BattleController.java
@@ -36,11 +36,9 @@ public class BattleController {
             @Parameter(description = "페이지 번호 (1부터 시작)", example = "1")
             @RequestParam(value = "page", defaultValue = "1") int page,
             @Parameter(description = "페이지 크기", example = "10")
-            @RequestParam(value = "size", defaultValue = "10") int size,
-            @Parameter(description = "콘텐츠 상태 (ALL, PENDING, PUBLISHED, REJECTED, ARCHIVED)", example = "ALL")
-            @RequestParam(value = "status", required = false, defaultValue = "ALL") String status
+            @RequestParam(value = "size", defaultValue = "10") int size
     ) {
-        return ApiResponse.onSuccess(battleService.getBattles(page, size, status));
+        return ApiResponse.onSuccess(battleService.getPublishedBattles(page, size));
     }
 
     @Operation(summary = "배틀 상세 조회")

--- a/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
@@ -38,6 +38,7 @@ public class BattleConverter {
                 .description(request.description())
                 .thumbnailUrl(request.thumbnailUrl())
                 .targetDate(request.targetDate())
+                .publishAt(request.publishAt())
                 .audioDuration(request.audioDuration())
                 .status(request.status())
                 .creatorType(BattleCreatorType.ADMIN)
@@ -65,6 +66,7 @@ public class BattleConverter {
                 battle.getTitle(),
                 urlProvider.getImageUrl(FileCategory.BATTLE, battle.getThumbnailUrl()),
                 battle.getStatus() != null ? battle.getStatus().name() : "PENDING",
+                battle.getPublishAt(),
                 battle.getCreatedAt()
         );
     }
@@ -78,6 +80,7 @@ public class BattleConverter {
                 urlProvider.getImageUrl(FileCategory.BATTLE, battle.getThumbnailUrl()),
                 battle.getAudioDuration(),
                 battle.getTargetDate(),
+                battle.getPublishAt(),
                 battle.getStatus(),
                 battle.getCreatorType(),
                 toTagResponses(tags, null),

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleSimpleResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleSimpleResponse.java
@@ -7,5 +7,6 @@ public record BattleSimpleResponse(
         String title,
         String thumbnailUrl,
         String status,
+        LocalDateTime publishAt,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/swyp/picke/domain/battle/entity/Battle.java
+++ b/src/main/java/com/swyp/picke/domain/battle/entity/Battle.java
@@ -49,6 +49,9 @@ public class Battle extends BaseEntity {
     @Column(name = "target_date")
     private LocalDate targetDate;
 
+    @Column(name = "publish_at")
+    private LocalDateTime publishAt;
+
     @Column(name = "audio_duration")
     private Integer audioDuration;
 
@@ -83,6 +86,7 @@ public class Battle extends BaseEntity {
             String description,
             String thumbnailUrl,
             LocalDate targetDate,
+            LocalDateTime publishAt,
             Integer audioDuration,
             BattleStatus status,
             BattleCreatorType creatorType,
@@ -93,6 +97,7 @@ public class Battle extends BaseEntity {
         this.description = description;
         this.thumbnailUrl = thumbnailUrl;
         this.targetDate = targetDate;
+        this.publishAt = publishAt;
         this.audioDuration = audioDuration;
         this.status = status;
         this.creatorType = creatorType;
@@ -110,6 +115,7 @@ public class Battle extends BaseEntity {
             String description,
             String thumbnailUrl,
             LocalDate targetDate,
+            LocalDateTime publishAt,
             Integer audioDuration,
             BattleStatus status
     ) {
@@ -128,6 +134,7 @@ public class Battle extends BaseEntity {
         if (targetDate != null) {
             this.targetDate = targetDate;
         }
+        this.publishAt = publishAt;
         if (audioDuration != null) {
             this.audioDuration = audioDuration;
         }
@@ -155,6 +162,10 @@ public class Battle extends BaseEntity {
 
     public void updateTargetDate(LocalDate targetDate) {
         this.targetDate = targetDate;
+    }
+
+    public void publish() {
+        this.status = BattleStatus.PUBLISHED;
     }
 
 }

--- a/src/main/java/com/swyp/picke/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/com/swyp/picke/domain/battle/repository/BattleRepository.java
@@ -57,6 +57,11 @@ public interface BattleRepository extends JpaRepository<Battle, Long> {
     Page<Battle> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
     Page<Battle> findByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(BattleStatus status, Pageable pageable);
     List<Battle> findByStatusAndDeletedAtIsNull(BattleStatus status);
+    Page<Battle> findByStatusAndPublishAtLessThanEqualAndDeletedAtIsNull(
+            BattleStatus status,
+            LocalDateTime publishAt,
+            Pageable pageable
+    );
 
     // 기본 조회용
     List<Battle> findByTargetDateAndStatusAndDeletedAtIsNull(LocalDate date, BattleStatus status);

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleService.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleService.java
@@ -14,6 +14,7 @@ import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
 import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.user.dto.response.UserBattleStatusResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface BattleService {
@@ -34,6 +35,8 @@ public interface BattleService {
 
     List<TodayBattleResponse> getNewBattles(List<Long> excludeIds);
 
+    BattleListResponse getPublishedBattles(int page, int size);
+
     BattleListResponse getBattles(int page, int size, String status);
 
     TodayBattleListResponse getTodayBattles();
@@ -53,4 +56,6 @@ public interface BattleService {
     AdminBattleDetailResponse updateBattle(Long battleId, AdminBattleUpdateRequest request);
 
     AdminBattleDeleteResponse deleteBattle(Long battleId);
+
+    int openReadyBattles(LocalDateTime now);
 }

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -19,6 +19,10 @@ import com.swyp.picke.domain.battle.repository.BattleOptionRepository;
 import com.swyp.picke.domain.battle.repository.BattleOptionTagRepository;
 import com.swyp.picke.domain.battle.repository.BattleRepository;
 import com.swyp.picke.domain.battle.repository.BattleTagRepository;
+import com.swyp.picke.domain.scenario.entity.Scenario;
+import com.swyp.picke.domain.scenario.enums.ScenarioStatus;
+import com.swyp.picke.domain.scenario.repository.ScenarioRepository;
+import com.swyp.picke.domain.scenario.service.ScenarioAudioPipelineService;
 import com.swyp.picke.domain.tag.entity.Tag;
 import com.swyp.picke.domain.tag.enums.TagType;
 import com.swyp.picke.domain.tag.repository.TagRepository;
@@ -40,6 +44,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -59,6 +65,7 @@ public class BattleServiceImpl implements BattleService {
     private static final int HOME_BEST_LIMIT = 3;
     private static final int HOME_TODAY_PICK_LIMIT = 1;
     private static final int HOME_NEW_LIMIT = 3;
+    private static final int PUBLISH_BATCH_SIZE = 100;
     private static final Pattern RESOURCE_IMAGE_PATH_PATTERN = Pattern.compile("/api/v1/resources/images/([A-Z_]+)/(.+)");
 
     private final BattleRepository battleRepository;
@@ -72,12 +79,22 @@ public class BattleServiceImpl implements BattleService {
     private final S3UploadService s3UploadService;
     private final LocalDraftFileStorageService localDraftFileStorageService;
     private final UserBattleService userBattleService;
+    private final ScenarioRepository scenarioRepository;
+    private final ScenarioAudioPipelineService scenarioAudioPipelineService;
 
     @Override
     public Battle findById(Long battleId) {
         Battle battle = battleRepository.findById(battleId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BATTLE_NOT_FOUND));
         if (battle.getDeletedAt() != null) {
+            throw new CustomException(ErrorCode.BATTLE_NOT_FOUND);
+        }
+        return battle;
+    }
+
+    private Battle findPublishedById(Long battleId) {
+        Battle battle = findById(battleId);
+        if (battle.getStatus() != BattleStatus.PUBLISHED) {
             throw new CustomException(ErrorCode.BATTLE_NOT_FOUND);
         }
         return battle;
@@ -146,6 +163,17 @@ public class BattleServiceImpl implements BattleService {
     }
 
     @Override
+    public BattleListResponse getPublishedBattles(int page, int size) {
+        int pageNumber = Math.max(0, page - 1);
+        PageRequest pageRequest = PageRequest.of(pageNumber, size);
+        Page<Battle> battlePage = battleRepository.findByStatusAndDeletedAtIsNullOrderByCreatedAtDesc(
+                BattleStatus.PUBLISHED,
+                pageRequest
+        );
+        return toBattleListResponse(battlePage);
+    }
+
+    @Override
     public BattleListResponse getBattles(int page, int size, String status) {
         int pageNumber = Math.max(0, page - 1);
         PageRequest pageRequest = PageRequest.of(pageNumber, size);
@@ -161,16 +189,7 @@ public class BattleServiceImpl implements BattleService {
             );
         }
 
-        List<BattleSimpleResponse> items = battlePage.getContent().stream()
-                .map(battleConverter::toSimpleResponse)
-                .toList();
-
-        return new BattleListResponse(
-                items,
-                battlePage.getNumber() + 1,
-                battlePage.getTotalPages(),
-                battlePage.getTotalElements()
-        );
+        return toBattleListResponse(battlePage);
     }
 
     @Override
@@ -203,7 +222,7 @@ public class BattleServiceImpl implements BattleService {
     @Override
     @Transactional
     public BattleUserDetailResponse getBattleDetail(Long battleId) {
-        Battle battle = findById(battleId);
+        Battle battle = findPublishedById(battleId);
         battle.increaseViewCount();
         List<Tag> tags = getTagsByBattle(battle);
         List<BattleOption> options = battleOptionRepository.findByBattle(battle);
@@ -240,14 +259,14 @@ public class BattleServiceImpl implements BattleService {
 
     @Override
     public BattleScenarioResponse getBattleScenario(Long battleId) {
-        Battle battle = findById(battleId);
+        Battle battle = findPublishedById(battleId);
         List<BattleOption> options = battleOptionRepository.findByBattle(battle);
         return battleConverter.toScenarioResponse(battle, options);
     }
 
     @Override
     public UserBattleStatusResponse getUserBattleStatus(Long battleId) {
-        Battle battle = findById(battleId);
+        Battle battle = findPublishedById(battleId);
         Long currentUserId = SecurityUtil.getCurrentUserId();
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -258,7 +277,7 @@ public class BattleServiceImpl implements BattleService {
     @Override
     @Transactional
     public BattleVoteResponse BattleVote(Long battleId, Long optionId) {
-        Battle battle = findById(battleId);
+        Battle battle = findPublishedById(battleId);
         BattleOption newOption = battleOptionRepository.findById(optionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BATTLE_OPTION_NOT_FOUND));
 
@@ -304,6 +323,7 @@ public class BattleServiceImpl implements BattleService {
                 request.description(),
                 resolvedThumbnailKey,
                 request.targetDate(),
+                request.publishAt(),
                 request.audioDuration(),
                 request.status()
         );
@@ -383,6 +403,7 @@ public class BattleServiceImpl implements BattleService {
                 request.description(),
                 resolvedThumbnailKey,
                 request.targetDate(),
+                request.publishAt(),
                 request.audioDuration(),
                 request.status()
         );
@@ -466,6 +487,100 @@ public class BattleServiceImpl implements BattleService {
         Battle battle = findById(battleId);
         battle.delete();
         return new AdminBattleDeleteResponse(true, LocalDateTime.now());
+    }
+
+    @Override
+    @Transactional
+    public int openReadyBattles(LocalDateTime now) {
+        int openedCount = 0;
+        PageRequest pageRequest = PageRequest.of(0, PUBLISH_BATCH_SIZE);
+
+        while (true) {
+            Page<Battle> readyPage = battleRepository.findByStatusAndPublishAtLessThanEqualAndDeletedAtIsNull(
+                    BattleStatus.PENDING,
+                    now,
+                    pageRequest
+            );
+            if (readyPage.isEmpty()) {
+                break;
+            }
+
+            for (Battle battle : readyPage.getContent()) {
+                publishBattleAssets(battle);
+                battle.publish();
+                publishScenarioIfPresent(battle);
+            }
+
+            openedCount += readyPage.getNumberOfElements();
+            battleRepository.flush();
+        }
+
+        return openedCount;
+    }
+
+    private BattleListResponse toBattleListResponse(Page<Battle> battlePage) {
+        List<BattleSimpleResponse> items = battlePage.getContent().stream()
+                .map(battleConverter::toSimpleResponse)
+                .toList();
+
+        return new BattleListResponse(
+                items,
+                battlePage.getNumber() + 1,
+                battlePage.getTotalPages(),
+                battlePage.getTotalElements()
+        );
+    }
+
+    private void publishBattleAssets(Battle battle) {
+        String resolvedThumbnailKey = resolveStoredImageKey(
+                battle.getThumbnailUrl(),
+                BattleStatus.PUBLISHED,
+                FileCategory.BATTLE
+        );
+        battle.update(
+                null,
+                null,
+                null,
+                resolvedThumbnailKey,
+                null,
+                battle.getPublishAt(),
+                null,
+                null
+        );
+
+        List<BattleOption> options = battleOptionRepository.findByBattle(battle);
+        for (BattleOption option : options) {
+            String resolvedImageKey = resolveStoredImageKey(
+                    option.getImageUrl(),
+                    BattleStatus.PUBLISHED,
+                    FileCategory.PHILOSOPHER
+            );
+            option.update(null, null, null, resolvedImageKey);
+        }
+    }
+
+    private void publishScenarioIfPresent(Battle battle) {
+        scenarioRepository.findByBattleId(battle.getId())
+                .filter(scenario -> scenario.getStatus() != ScenarioStatus.ARCHIVED)
+                .ifPresent(scenario -> {
+                    scenario.updateStatus(ScenarioStatus.PUBLISHED);
+                    triggerScenarioAudioAfterCommit(scenario);
+                });
+    }
+
+    private void triggerScenarioAudioAfterCommit(Scenario scenario) {
+        Long scenarioId = scenario.getId();
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    scenarioAudioPipelineService.generateAndMergeAudioAsync(scenarioId);
+                }
+            });
+            return;
+        }
+
+        scenarioAudioPipelineService.generateAndMergeAudioAsync(scenarioId);
     }
 
     private List<TodayBattleResponse> convertToTodayResponses(List<Battle> battles) {

--- a/src/main/java/com/swyp/picke/domain/perspective/controller/BestCommentSchedulerTestController.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/controller/BestCommentSchedulerTestController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "[Test] BestCommentScheduler", description = "스케줄러 테스트 API")
 @RestController
 @RequestMapping("/api/test/scheduler")

--- a/src/main/java/com/swyp/picke/domain/perspective/controller/BestCommentSchedulerTestController.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/controller/BestCommentSchedulerTestController.java
@@ -2,6 +2,7 @@ package com.swyp.picke.domain.perspective.controller;
 
 import com.swyp.picke.domain.perspective.scheduler.BestCommentScheduler;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "[Test] BestCommentScheduler", description = "스케줄러 테스트 API")
 @RestController
 @RequestMapping("/api/test/scheduler")

--- a/src/main/java/com/swyp/picke/domain/poll/converter/PollConverter.java
+++ b/src/main/java/com/swyp/picke/domain/poll/converter/PollConverter.java
@@ -26,6 +26,7 @@ public class PollConverter {
                 .titlePrefix(request.titlePrefix())
                 .titleSuffix(request.titleSuffix())
                 .targetDate(request.targetDate())
+                .publishAt(request.publishAt())
                 .status(request.status())
                 .build();
     }
@@ -42,7 +43,9 @@ public class PollConverter {
                 poll.getId(),
                 poll.getTitlePrefix(),
                 poll.getTitleSuffix(),
-                poll.getStatus()
+                poll.getStatus(),
+                poll.getPublishAt(),
+                poll.getCreatedAt()
         );
     }
 
@@ -52,6 +55,7 @@ public class PollConverter {
                 poll.getTitlePrefix(),
                 poll.getTitleSuffix(),
                 poll.getTargetDate(),
+                poll.getPublishAt(),
                 poll.getStatus(),
                 toOptionResponses(options)
         );

--- a/src/main/java/com/swyp/picke/domain/poll/dto/response/PollSimpleResponse.java
+++ b/src/main/java/com/swyp/picke/domain/poll/dto/response/PollSimpleResponse.java
@@ -8,7 +8,9 @@ public record PollSimpleResponse(
         Long pollId,
         String titlePrefix,
         String titleSuffix,
-        PollStatus status
+        PollStatus status,
+        LocalDateTime publishAt,
+        LocalDateTime createdAt
 ) {
 }
 

--- a/src/main/java/com/swyp/picke/domain/poll/entity/Poll.java
+++ b/src/main/java/com/swyp/picke/domain/poll/entity/Poll.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +34,9 @@ public class Poll extends BaseEntity {
     @Column(name = "target_date")
     private LocalDate targetDate;
 
+    @Column(name = "publish_at")
+    private LocalDateTime publishAt;
+
     @Column(name = "total_participants_count", nullable = false)
     private Long totalParticipantsCount;
 
@@ -44,10 +48,11 @@ public class Poll extends BaseEntity {
     private final List<PollOption> options = new ArrayList<>();
 
     @Builder
-    public Poll(String titlePrefix, String titleSuffix, LocalDate targetDate, PollStatus status) {
+    public Poll(String titlePrefix, String titleSuffix, LocalDate targetDate, LocalDateTime publishAt, PollStatus status) {
         this.titlePrefix = titlePrefix;
         this.titleSuffix = titleSuffix;
         this.targetDate = targetDate;
+        this.publishAt = publishAt;
         this.status = status;
         this.totalParticipantsCount = 0L;
     }
@@ -57,6 +62,14 @@ public class Poll extends BaseEntity {
         if (titleSuffix != null) this.titleSuffix = titleSuffix;
         if (targetDate != null) this.targetDate = targetDate;
         if (status != null) this.status = status;
+    }
+
+    public void updatePublishAt(LocalDateTime publishAt) {
+        this.publishAt = publishAt;
+    }
+
+    public void publish() {
+        this.status = PollStatus.PUBLISHED;
     }
 
     public void increaseTotalParticipantsCount() {

--- a/src/main/java/com/swyp/picke/domain/poll/repository/PollRepository.java
+++ b/src/main/java/com/swyp/picke/domain/poll/repository/PollRepository.java
@@ -3,6 +3,7 @@ package com.swyp.picke.domain.poll.repository;
 import com.swyp.picke.domain.poll.entity.Poll;
 import com.swyp.picke.domain.poll.enums.PollStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface PollRepository extends JpaRepository<Poll, Long> {
     Page<Poll> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<Poll> findByStatusOrderByCreatedAtDesc(PollStatus status, Pageable pageable);
+    Page<Poll> findByStatusAndPublishAtLessThanEqual(
+            PollStatus status,
+            LocalDateTime publishAt,
+            Pageable pageable
+    );
 
     @Query("SELECT p FROM Poll p WHERE p.status = :status AND p.targetDate = :targetDate ORDER BY p.createdAt ASC")
     List<Poll> findTodayPicks(

--- a/src/main/java/com/swyp/picke/domain/poll/service/PollService.java
+++ b/src/main/java/com/swyp/picke/domain/poll/service/PollService.java
@@ -8,12 +8,15 @@ import com.swyp.picke.domain.poll.dto.response.PollDetailResponse;
 import com.swyp.picke.domain.poll.dto.response.PollListResponse;
 import com.swyp.picke.domain.poll.entity.Poll;
 import com.swyp.picke.domain.poll.entity.PollOption;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PollService {
     Poll findById(Long pollId);
 
     PollListResponse getPolls(int page, int size);
+
+    PollListResponse getPolls(int page, int size, String status);
 
     List<Poll> getTodayPicks(int limit);
 
@@ -30,6 +33,8 @@ public interface PollService {
     AdminPollDetailResponse updatePoll(Long pollId, AdminPollUpdateRequest request);
 
     AdminPollDeleteResponse deletePoll(Long pollId);
+
+    int openReadyPolls(LocalDateTime now);
 }
 
 

--- a/src/main/java/com/swyp/picke/domain/poll/service/PollServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/poll/service/PollServiceImpl.java
@@ -37,6 +37,8 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class PollServiceImpl implements PollService {
 
+    private static final int PUBLISH_BATCH_SIZE = 100;
+
     private final PollRepository pollRepository;
     private final PollOptionRepository pollOptionRepository;
     private final PollConverter pollConverter;
@@ -50,7 +52,23 @@ public class PollServiceImpl implements PollService {
     @Override
     public PollListResponse getPolls(int page, int size) {
         int pageNumber = Math.max(0, page - 1);
-        Page<Poll> pollPage = pollRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(pageNumber, size));
+        Page<Poll> pollPage = pollRepository.findByStatusOrderByCreatedAtDesc(
+                PollStatus.PUBLISHED,
+                PageRequest.of(pageNumber, size)
+        );
+        return pollConverter.toListResponse(pollPage);
+    }
+
+    @Override
+    public PollListResponse getPolls(int page, int size, String status) {
+        int pageNumber = Math.max(0, page - 1);
+        PageRequest pageRequest = PageRequest.of(pageNumber, size);
+        PollStatus pollStatus = parsePollStatus(status);
+
+        Page<Poll> pollPage = pollStatus == null
+                ? pollRepository.findAllByOrderByCreatedAtDesc(pageRequest)
+                : pollRepository.findByStatusOrderByCreatedAtDesc(pollStatus, pageRequest);
+
         return pollConverter.toListResponse(pollPage);
     }
 
@@ -77,6 +95,9 @@ public class PollServiceImpl implements PollService {
     @Override
     public PollDetailResponse getPollDetail(Long pollId) {
         Poll poll = findById(pollId);
+        if (poll.getStatus() != PollStatus.PUBLISHED) {
+            throw new CustomException(ErrorCode.BATTLE_NOT_FOUND);
+        }
         List<PollOption> options = pollOptionRepository.findByPollOrderByDisplayOrderAscLabelAscIdAsc(poll);
         return pollConverter.toDetailResponse(poll, options);
     }
@@ -126,6 +147,7 @@ public class PollServiceImpl implements PollService {
                 request.targetDate(),
                 request.status()
         );
+        poll.updatePublishAt(request.publishAt());
 
         if (request.options() != null) {
             List<PollOption> existingOptions = pollOptionRepository.findByPollOrderByDisplayOrderAscLabelAscIdAsc(poll);
@@ -174,11 +196,47 @@ public class PollServiceImpl implements PollService {
         return new AdminPollDeleteResponse(true, LocalDateTime.now());
     }
 
+    @Override
+    @Transactional
+    public int openReadyPolls(LocalDateTime now) {
+        int openedCount = 0;
+        PageRequest pageRequest = PageRequest.of(0, PUBLISH_BATCH_SIZE);
+
+        while (true) {
+            Page<Poll> readyPage = pollRepository.findByStatusAndPublishAtLessThanEqual(
+                    PollStatus.PENDING,
+                    now,
+                    pageRequest
+            );
+            if (readyPage.isEmpty()) {
+                break;
+            }
+
+            readyPage.getContent().forEach(Poll::publish);
+            openedCount += readyPage.getNumberOfElements();
+            pollRepository.flush();
+        }
+
+        return openedCount;
+    }
+
     private int resolveDisplayOrder(Integer requestedOrder, int fallbackOrder) {
         if (requestedOrder == null || requestedOrder < 1) {
             return fallbackOrder;
         }
         return requestedOrder;
+    }
+
+    private PollStatus parsePollStatus(String status) {
+        if (status == null || status.isBlank() || "ALL".equalsIgnoreCase(status)) {
+            return null;
+        }
+
+        try {
+            return PollStatus.valueOf(status.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
     }
 
     private void ensureTodayPicks(LocalDate today, int requiredCount) {

--- a/src/main/java/com/swyp/picke/domain/quiz/converter/QuizConverter.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/converter/QuizConverter.java
@@ -25,6 +25,7 @@ public class QuizConverter {
         return Quiz.builder()
                 .title(request.title())
                 .targetDate(request.targetDate())
+                .publishAt(request.publishAt())
                 .status(request.status())
                 .build();
     }
@@ -41,6 +42,7 @@ public class QuizConverter {
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getStatus(),
+                quiz.getPublishAt(),
                 quiz.getCreatedAt()
         );
     }
@@ -50,6 +52,7 @@ public class QuizConverter {
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getTargetDate(),
+                quiz.getPublishAt(),
                 quiz.getStatus(),
                 toOptionResponses(options)
         );

--- a/src/main/java/com/swyp/picke/domain/quiz/dto/response/QuizSimpleResponse.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/dto/response/QuizSimpleResponse.java
@@ -8,6 +8,7 @@ public record QuizSimpleResponse(
         Long quizId,
         String title,
         QuizStatus status,
+        LocalDateTime publishAt,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/swyp/picke/domain/quiz/entity/Quiz.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/entity/Quiz.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +31,9 @@ public class Quiz extends BaseEntity {
     @Column(name = "target_date")
     private LocalDate targetDate;
 
+    @Column(name = "publish_at")
+    private LocalDateTime publishAt;
+
     @Column(name = "total_participants_count", nullable = false)
     private Long totalParticipantsCount;
 
@@ -41,9 +45,10 @@ public class Quiz extends BaseEntity {
     private final List<QuizOption> options = new ArrayList<>();
 
     @Builder
-    public Quiz(String title, LocalDate targetDate, QuizStatus status) {
+    public Quiz(String title, LocalDate targetDate, LocalDateTime publishAt, QuizStatus status) {
         this.title = title;
         this.targetDate = targetDate;
+        this.publishAt = publishAt;
         this.status = status;
         this.totalParticipantsCount = 0L;
     }
@@ -52,6 +57,14 @@ public class Quiz extends BaseEntity {
         if (title != null) this.title = title;
         if (targetDate != null) this.targetDate = targetDate;
         if (status != null) this.status = status;
+    }
+
+    public void updatePublishAt(LocalDateTime publishAt) {
+        this.publishAt = publishAt;
+    }
+
+    public void publish() {
+        this.status = QuizStatus.PUBLISHED;
     }
 
     public void increaseTotalParticipantsCount() {

--- a/src/main/java/com/swyp/picke/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/repository/QuizRepository.java
@@ -3,6 +3,7 @@ package com.swyp.picke.domain.quiz.repository;
 import com.swyp.picke.domain.quiz.entity.Quiz;
 import com.swyp.picke.domain.quiz.enums.QuizStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
     Page<Quiz> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<Quiz> findByStatusOrderByCreatedAtDesc(QuizStatus status, Pageable pageable);
+    Page<Quiz> findByStatusAndPublishAtLessThanEqual(
+            QuizStatus status,
+            LocalDateTime publishAt,
+            Pageable pageable
+    );
 
     @Query("SELECT q FROM Quiz q WHERE q.status = :status AND q.targetDate = :targetDate ORDER BY q.createdAt ASC")
     List<Quiz> findTodayPicks(

--- a/src/main/java/com/swyp/picke/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/service/QuizService.java
@@ -8,12 +8,15 @@ import com.swyp.picke.domain.quiz.dto.response.QuizDetailResponse;
 import com.swyp.picke.domain.quiz.dto.response.QuizListResponse;
 import com.swyp.picke.domain.quiz.entity.Quiz;
 import com.swyp.picke.domain.quiz.entity.QuizOption;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface QuizService {
     Quiz findById(Long quizId);
 
     QuizListResponse getQuizzes(int page, int size);
+
+    QuizListResponse getQuizzes(int page, int size, String status);
 
     List<Quiz> getTodayPicks(int limit);
 
@@ -30,6 +33,8 @@ public interface QuizService {
     AdminQuizDetailResponse updateQuiz(Long quizId, AdminQuizUpdateRequest request);
 
     AdminQuizDeleteResponse deleteQuiz(Long quizId);
+
+    int openReadyQuizzes(LocalDateTime now);
 }
 
 

--- a/src/main/java/com/swyp/picke/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/quiz/service/QuizServiceImpl.java
@@ -37,6 +37,8 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class QuizServiceImpl implements QuizService {
 
+    private static final int PUBLISH_BATCH_SIZE = 100;
+
     private final QuizRepository quizRepository;
     private final QuizOptionRepository quizOptionRepository;
     private final QuizConverter quizConverter;
@@ -50,7 +52,23 @@ public class QuizServiceImpl implements QuizService {
     @Override
     public QuizListResponse getQuizzes(int page, int size) {
         int pageNumber = Math.max(0, page - 1);
-        Page<Quiz> quizPage = quizRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(pageNumber, size));
+        Page<Quiz> quizPage = quizRepository.findByStatusOrderByCreatedAtDesc(
+                QuizStatus.PUBLISHED,
+                PageRequest.of(pageNumber, size)
+        );
+        return quizConverter.toListResponse(quizPage);
+    }
+
+    @Override
+    public QuizListResponse getQuizzes(int page, int size, String status) {
+        int pageNumber = Math.max(0, page - 1);
+        PageRequest pageRequest = PageRequest.of(pageNumber, size);
+        QuizStatus quizStatus = parseQuizStatus(status);
+
+        Page<Quiz> quizPage = quizStatus == null
+                ? quizRepository.findAllByOrderByCreatedAtDesc(pageRequest)
+                : quizRepository.findByStatusOrderByCreatedAtDesc(quizStatus, pageRequest);
+
         return quizConverter.toListResponse(quizPage);
     }
 
@@ -77,6 +95,9 @@ public class QuizServiceImpl implements QuizService {
     @Override
     public QuizDetailResponse getQuizDetail(Long quizId) {
         Quiz quiz = findById(quizId);
+        if (quiz.getStatus() != QuizStatus.PUBLISHED) {
+            throw new CustomException(ErrorCode.BATTLE_NOT_FOUND);
+        }
         List<QuizOption> options = quizOptionRepository.findByQuizOrderByDisplayOrderAscLabelAscIdAsc(quiz);
         return quizConverter.toDetailResponse(quiz, options);
     }
@@ -123,6 +144,7 @@ public class QuizServiceImpl implements QuizService {
     public AdminQuizDetailResponse updateQuiz(Long quizId, AdminQuizUpdateRequest request) {
         Quiz quiz = findById(quizId);
         quiz.update(request.title(), request.targetDate(), request.status());
+        quiz.updatePublishAt(request.publishAt());
 
         if (request.options() != null) {
             List<QuizOption> existingOptions = quizOptionRepository.findByQuizOrderByDisplayOrderAscLabelAscIdAsc(quiz);
@@ -178,11 +200,47 @@ public class QuizServiceImpl implements QuizService {
         return new AdminQuizDeleteResponse(true, LocalDateTime.now());
     }
 
+    @Override
+    @Transactional
+    public int openReadyQuizzes(LocalDateTime now) {
+        int openedCount = 0;
+        PageRequest pageRequest = PageRequest.of(0, PUBLISH_BATCH_SIZE);
+
+        while (true) {
+            Page<Quiz> readyPage = quizRepository.findByStatusAndPublishAtLessThanEqual(
+                    QuizStatus.PENDING,
+                    now,
+                    pageRequest
+            );
+            if (readyPage.isEmpty()) {
+                break;
+            }
+
+            readyPage.getContent().forEach(Quiz::publish);
+            openedCount += readyPage.getNumberOfElements();
+            quizRepository.flush();
+        }
+
+        return openedCount;
+    }
+
     private int resolveDisplayOrder(Integer requestedOrder, int fallbackOrder) {
         if (requestedOrder == null || requestedOrder < 1) {
             return fallbackOrder;
         }
         return requestedOrder;
+    }
+
+    private QuizStatus parseQuizStatus(String status) {
+        if (status == null || status.isBlank() || "ALL".equalsIgnoreCase(status)) {
+            return null;
+        }
+
+        try {
+            return QuizStatus.valueOf(status.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
     }
 
     private void ensureTodayPicks(LocalDate today, int requiredCount) {

--- a/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
+++ b/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
@@ -4,6 +4,7 @@ import com.swyp.picke.domain.reward.dto.request.AdMobRewardRequest;
 import com.swyp.picke.domain.reward.dto.response.AdMobRewardResponse;
 import com.swyp.picke.domain.reward.service.AdMobRewardService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@Hidden
 @Tag(name = "보상 API", description = "AdMob 광고 보상 관련 API")
 @RestController
 @RequestMapping("/api/v1/admob")

--- a/src/main/java/com/swyp/picke/domain/search/controller/SearchController.java
+++ b/src/main/java/com/swyp/picke/domain/search/controller/SearchController.java
@@ -4,6 +4,8 @@ import com.swyp.picke.domain.search.dto.response.SearchBattleListResponse;
 import com.swyp.picke.domain.search.enums.SearchSortType;
 import com.swyp.picke.domain.search.service.SearchService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,10 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/search")
+@Tag(name = "검색 API", description = "배틀 검색")
 public class SearchController {
 
     private final SearchService searchService;
 
+    @Operation(summary = "배틀 검색", description = "카테고리와 정렬 조건으로 배틀을 검색합니다.")
     @GetMapping("/battles")
     public ApiResponse<SearchBattleListResponse> searchBattles(
             @RequestParam(required = false) String category,

--- a/src/main/java/com/swyp/picke/domain/share/controller/ShareApiController.java
+++ b/src/main/java/com/swyp/picke/domain/share/controller/ShareApiController.java
@@ -4,6 +4,9 @@ import com.swyp.picke.domain.share.dto.response.RecapShareKeyResponse;
 import com.swyp.picke.domain.share.service.ShareService;
 import com.swyp.picke.domain.user.dto.response.RecapResponse;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,11 +15,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
 @RequestMapping("/api/v1/share")
 @RequiredArgsConstructor
+@Tag(name = "공유 API", description = "공유 URL 및 리캡 공유 조회")
 public class ShareApiController {
 
     @Value("${picke.baseUrl}")
@@ -24,23 +26,27 @@ public class ShareApiController {
 
     private final ShareService shareService;
 
+    @Operation(summary = "리포트 공유 URL 조회", description = "리포트 공유에 사용할 URL을 조회합니다.")
     @GetMapping("/report")
     public ApiResponse<Map<String, String>> getReportShareUrl(@RequestParam Long reportId) {
         String shareUrl = baseUrl + "/report/" + reportId;
         return ApiResponse.onSuccess(Map.of("shareUrl", shareUrl));
     }
 
+    @Operation(summary = "배틀 공유 URL 조회", description = "배틀 공유에 사용할 URL을 조회합니다.")
     @GetMapping("/battle")
     public ApiResponse<Map<String, String>> getBattleShareUrl(@RequestParam Long battleId) {
         String shareUrl = baseUrl + "/battle/" + battleId;
         return ApiResponse.onSuccess(Map.of("shareUrl", shareUrl));
     }
 
+    @Operation(summary = "리캡 공유 키 발급", description = "내 리캡을 공유하기 위한 공유 키를 발급합니다.")
     @GetMapping("/recap")
     public ApiResponse<RecapShareKeyResponse> getRecapShareKey() {
         return ApiResponse.onSuccess(shareService.getRecapShareKey());
     }
 
+    @Operation(summary = "공유 리캡 조회", description = "공유 키로 공개된 리캡 정보를 조회합니다.")
     @GetMapping("/recap/{shareKey}")
     public ApiResponse<RecapResponse> getSharedRecap(@PathVariable String shareKey) {
         return ApiResponse.onSuccess(shareService.getSharedRecap(shareKey));

--- a/src/main/java/com/swyp/picke/domain/user/controller/MypageController.java
+++ b/src/main/java/com/swyp/picke/domain/user/controller/MypageController.java
@@ -15,6 +15,8 @@ import com.swyp.picke.domain.user.enums.VoteSide;
 import com.swyp.picke.domain.user.service.MypageService;
 import com.swyp.picke.domain.user.service.UserService;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,11 +29,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/me")
+@Tag(name = "마이페이지 API", description = "마이페이지, 활동 내역, 알림 설정 조회 및 수정")
 public class MypageController {
 
     private final UserService userService;
     private final MypageService mypageService;
 
+    @Operation(summary = "내 프로필 수정", description = "사용자의 프로필 정보를 수정합니다.")
     @PatchMapping("/profile")
     public ApiResponse<MyProfileResponse> updateMyProfile(
             @Valid @RequestBody UpdateUserProfileRequest request
@@ -39,16 +43,19 @@ public class MypageController {
         return ApiResponse.onSuccess(userService.updateMyProfile(request));
     }
 
+    @Operation(summary = "마이페이지 조회", description = "사용자의 마이페이지 정보를 조회합니다.")
     @GetMapping("/mypage")
     public ApiResponse<MypageResponse> getMypage() {
         return ApiResponse.onSuccess(mypageService.getMypage());
     }
 
+    @Operation(summary = "내 리캡 조회", description = "사용자의 리캡 정보를 조회합니다.")
     @GetMapping("/recap")
     public ApiResponse<RecapResponse> getRecap() {
         return ApiResponse.onSuccess(mypageService.getRecap());
     }
 
+    @Operation(summary = "내 배틀 참여 기록 조회", description = "사용자의 배틀 참여 기록을 조회합니다.")
     @GetMapping("/battle-records")
     public ApiResponse<BattleRecordListResponse> getBattleRecords(
             @RequestParam(required = false) Integer offset,
@@ -58,6 +65,7 @@ public class MypageController {
         return ApiResponse.onSuccess(mypageService.getBattleRecords(offset, size, voteSide));
     }
 
+    @Operation(summary = "내 콘텐츠 활동 내역 조회", description = "사용자의 콘텐츠 활동 내역을 조회합니다.")
     @GetMapping("/content-activities")
     public ApiResponse<ContentActivityListResponse> getContentActivities(
             @RequestParam(required = false) Integer offset,
@@ -67,6 +75,7 @@ public class MypageController {
         return ApiResponse.onSuccess(mypageService.getContentActivities(offset, size, activityType));
     }
 
+    @Operation(summary = "크레딧 히스토리 조회", description = "사용자의 크레딧 지급 및 사용 내역을 조회합니다.")
     @GetMapping("/credits/history")
     public ApiResponse<CreditHistoryListResponse> getCreditHistory(
             @RequestParam(required = false) Integer offset,
@@ -75,11 +84,13 @@ public class MypageController {
         return ApiResponse.onSuccess(mypageService.getCreditHistory(offset, size));
     }
 
+    @Operation(summary = "알림 설정 조회", description = "사용자의 알림 설정 정보를 조회합니다.")
     @GetMapping("/notification-settings")
     public ApiResponse<NotificationSettingsResponse> getNotificationSettings() {
         return ApiResponse.onSuccess(mypageService.getNotificationSettings());
     }
 
+    @Operation(summary = "알림 설정 수정", description = "사용자의 알림 설정 정보를 수정합니다.")
     @PatchMapping("/notification-settings")
     public ApiResponse<NotificationSettingsResponse> updateNotificationSettings(
             @RequestBody UpdateNotificationSettingsRequest request

--- a/src/main/java/com/swyp/picke/domain/user/entity/UserTendencyScoreHistory.java
+++ b/src/main/java/com/swyp/picke/domain/user/entity/UserTendencyScoreHistory.java
@@ -28,6 +28,7 @@ public class UserTendencyScoreHistory extends BaseEntity {
 
     private int individual;
 
+    @Column(name = "change_score")
     private int change;
 
     @Column(name = "inner_score")

--- a/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
@@ -13,6 +13,7 @@ import com.swyp.picke.domain.vote.service.PollVoteService;
 import com.swyp.picke.domain.vote.service.QuizVoteService;
 import com.swyp.picke.domain.vote.sse.SseEmitterRegistry;
 import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
@@ -144,7 +145,7 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @io.swagger.v3.oas.annotations.Hidden
+    @Hidden
     @Operation(summary = "[관리자] 배틀 투표 기록 삭제")
     @DeleteMapping("/admin/votes/battle/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -153,7 +154,7 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @io.swagger.v3.oas.annotations.Hidden
+    @Hidden
     @Operation(summary = "[관리자] 퀴즈 투표 기록 삭제")
     @DeleteMapping("/admin/votes/quiz/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -162,7 +163,7 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @io.swagger.v3.oas.annotations.Hidden
+    @Hidden
     @Operation(summary = "[관리자] 투표 콘텐츠 투표 기록 삭제")
     @DeleteMapping("/admin/votes/poll/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
@@ -144,6 +144,7 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
+    @io.swagger.v3.oas.annotations.Hidden
     @Operation(summary = "[관리자] 배틀 투표 기록 삭제")
     @DeleteMapping("/admin/votes/battle/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -152,6 +153,7 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
+    @io.swagger.v3.oas.annotations.Hidden
     @Operation(summary = "[관리자] 퀴즈 투표 기록 삭제")
     @DeleteMapping("/admin/votes/quiz/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -160,6 +162,7 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
+    @io.swagger.v3.oas.annotations.Hidden
     @Operation(summary = "[관리자] 투표 콘텐츠 투표 기록 삭제")
     @DeleteMapping("/admin/votes/poll/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/swyp/picke/global/config/SwaggerConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/SwaggerConfig.java
@@ -2,16 +2,78 @@ package com.swyp.picke.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
+    private static final Set<String> FE_USED_OPERATIONS = Set.of(
+            "POST /api/v1/auth/refresh",
+            "POST /api/v1/auth/login/{provider}",
+            "POST /api/v1/auth/logout",
+            "DELETE /api/v1/me",
+            "GET /api/v1/home",
+            "GET /api/v1/battles/{battleId}",
+            "GET /api/v1/battles/{battleId}/status",
+            "GET /api/v1/battles/today",
+            "GET /api/v1/search/battles",
+            "GET /api/v1/battles/{battleId}/perspectives",
+            "POST /api/v1/battles/{battleId}/perspectives",
+            "GET /api/v1/battles/{battleId}/perspectives/me",
+            "GET /api/v1/perspectives/{perspectiveId}",
+            "DELETE /api/v1/perspectives/{perspectiveId}",
+            "PATCH /api/v1/perspectives/{perspectiveId}",
+            "POST /api/v1/perspectives/{perspectiveId}/moderation/retry",
+            "GET /api/v1/perspectives/{perspectiveId}/likes",
+            "POST /api/v1/perspectives/{perspectiveId}/likes",
+            "DELETE /api/v1/perspectives/{perspectiveId}/likes",
+            "POST /api/v1/perspectives/{perspectiveId}/reports",
+            "GET /api/v1/perspectives/{perspectiveId}/comments/labeled",
+            "POST /api/v1/perspectives/{perspectiveId}/comments",
+            "DELETE /api/v1/perspectives/{perspectiveId}/comments/{commentId}",
+            "PATCH /api/v1/perspectives/{perspectiveId}/comments/{commentId}",
+            "POST /api/v1/comments/{commentId}/likes",
+            "DELETE /api/v1/comments/{commentId}/likes",
+            "POST /api/v1/perspectives/{perspectiveId}/comments/{commentId}/reports",
+            "POST /api/v1/battles/{battleId}/votes/pre",
+            "POST /api/v1/battles/{battleId}/votes/post",
+            "GET /api/v1/battles/{battleId}/vote-stats",
+            "GET /api/v1/battles/{battleId}/votes/me",
+            "POST /api/v1/battles/{battleId}/poll-vote",
+            "GET /api/v1/battles/{battleId}/poll-vote/me",
+            "POST /api/v1/battles/{battleId}/quiz-vote",
+            "GET /api/v1/battles/{battleId}/quiz-vote/me",
+            "GET /api/v1/notifications",
+            "GET /api/v1/notifications/{notificationId}",
+            "PATCH /api/v1/notifications/{notificationId}/read",
+            "PATCH /api/v1/notifications/read-all",
+            "GET /api/v1/me/battle-records",
+            "GET /api/v1/me/content-activities",
+            "GET /api/v1/me/mypage",
+            "GET /api/v1/me/notification-settings",
+            "PATCH /api/v1/me/notification-settings",
+            "PATCH /api/v1/me/profile",
+            "GET /api/v1/me/recap",
+            "GET /api/v1/me/credits/history",
+            "GET /api/v1/share/report",
+            "GET /api/v1/share/battle",
+            "GET /api/v1/share/recap",
+            "GET /api/v1/share/recap/{shareKey}",
+            "POST /api/v1/battles/proposals",
+            "GET /api/v1/battles/{battleId}/recommendations/interesting",
+            "GET /api/v1/battles/{battleId}/scenario"
+    );
 
     @Bean
     public OpenAPI openAPI() {
@@ -50,5 +112,67 @@ public class SwaggerConfig {
                 .components(new Components()
                                     .addSecuritySchemes("bearerAuth", securityScheme))
                 .addSecurityItem(securityRequirement);
+    }
+
+    @Bean
+    public OpenApiCustomizer feUsedApiOnlyCustomizer() {
+        return openApi -> {
+            if (openApi.getPaths() == null) {
+                return;
+            }
+
+            List<String> emptyPaths = new ArrayList<>();
+
+            openApi.getPaths().forEach((path, pathItem) -> {
+                List<PathItem.HttpMethod> methods =
+                        new ArrayList<>(pathItem.readOperationsMap().keySet());
+
+                for (PathItem.HttpMethod method : methods) {
+                    String operationKey = method.name() + " " + path;
+                    if (!FE_USED_OPERATIONS.contains(operationKey)) {
+                        clearOperation(pathItem, method);
+                    }
+                }
+
+                if (pathItem.readOperationsMap().isEmpty()) {
+                    emptyPaths.add(path);
+                }
+            });
+
+            emptyPaths.forEach(openApi.getPaths()::remove);
+            removeUnusedTags(openApi);
+        };
+    }
+
+    private void removeUnusedTags(OpenAPI openApi) {
+        if (openApi.getTags() == null || openApi.getPaths() == null) {
+            return;
+        }
+
+        Set<String> usedTags = new HashSet<>();
+        openApi.getPaths().values().forEach(pathItem ->
+                pathItem.readOperations().forEach(operation -> {
+                    if (operation.getTags() != null) {
+                        usedTags.addAll(operation.getTags());
+                    }
+                })
+        );
+
+        openApi.setTags(openApi.getTags().stream()
+                .filter(tag -> usedTags.contains(tag.getName()))
+                .toList());
+    }
+
+    private void clearOperation(PathItem pathItem, PathItem.HttpMethod method) {
+        switch (method) {
+            case GET -> pathItem.setGet(null);
+            case PUT -> pathItem.setPut(null);
+            case POST -> pathItem.setPost(null);
+            case DELETE -> pathItem.setDelete(null);
+            case OPTIONS -> pathItem.setOptions(null);
+            case HEAD -> pathItem.setHead(null);
+            case PATCH -> pathItem.setPatch(null);
+            case TRACE -> pathItem.setTrace(null);
+        }
     }
 }

--- a/src/main/java/com/swyp/picke/global/infra/s3/controller/FileUploadController.java
+++ b/src/main/java/com/swyp/picke/global/infra/s3/controller/FileUploadController.java
@@ -6,6 +6,7 @@ import com.swyp.picke.global.infra.s3.dto.FileUploadResponse;
 import com.swyp.picke.global.infra.s3.enums.FileCategory;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
 import com.swyp.picke.global.infra.s3.service.S3UploadService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,7 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "파일 업로드 API", description = "관리자 파일 업로드 (S3 / 로컬 임시저장)")
 @RestController
 @RequestMapping("/api/v1/files")

--- a/src/main/java/com/swyp/picke/global/infra/s3/controller/FileUploadController.java
+++ b/src/main/java/com/swyp/picke/global/infra/s3/controller/FileUploadController.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "파일 업로드 API", description = "관리자 파일 업로드 (S3 / 로컬 임시저장)")
 @RestController
 @RequestMapping("/api/v1/files")

--- a/src/main/java/com/swyp/picke/global/infra/s3/controller/ResourceRedirectController.java
+++ b/src/main/java/com/swyp/picke/global/infra/s3/controller/ResourceRedirectController.java
@@ -3,6 +3,7 @@ package com.swyp.picke.global.infra.s3.controller;
 import com.swyp.picke.global.infra.local.service.LocalDraftFileStorageService;
 import com.swyp.picke.global.infra.s3.enums.FileCategory;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
-@io.swagger.v3.oas.annotations.Hidden
+@Hidden
 @Tag(name = "리소스 리다이렉트 API", description = "공개 리소스 요청을 S3 Presigned URL 또는 로컬 임시파일로 전달")
 @RestController
 @RequestMapping("/api/v1/resources")

--- a/src/main/java/com/swyp/picke/global/infra/s3/controller/ResourceRedirectController.java
+++ b/src/main/java/com/swyp/picke/global/infra/s3/controller/ResourceRedirectController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
+@io.swagger.v3.oas.annotations.Hidden
 @Tag(name = "리소스 리다이렉트 API", description = "공개 리소스 요청을 S3 Presigned URL 또는 로컬 임시파일로 전달")
 @RestController
 @RequestMapping("/api/v1/resources")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        jdbc:
+          time_zone: Asia/Seoul
+
+  jackson:
+    time-zone: Asia/Seoul
 
   # 3. spring.cloud 하위로 AWS 및 GCP 인프라 세팅 이동 (오류 해결 핵심)
   cloud:

--- a/src/main/resources/db/migration/V20260519_01__add_publish_at_to_contents.sql
+++ b/src/main/resources/db/migration/V20260519_01__add_publish_at_to_contents.sql
@@ -1,0 +1,18 @@
+ALTER TABLE battles
+    ADD COLUMN IF NOT EXISTS publish_at TIMESTAMP;
+
+ALTER TABLE quizzes
+    ADD COLUMN IF NOT EXISTS publish_at TIMESTAMP;
+
+ALTER TABLE poll_contents
+    ADD COLUMN IF NOT EXISTS publish_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_battles_status_publish_at
+    ON battles (status, publish_at)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_quizzes_status_publish_at
+    ON quizzes (status, publish_at);
+
+CREATE INDEX IF NOT EXISTS idx_poll_contents_status_publish_at
+    ON poll_contents (status, publish_at);

--- a/src/main/resources/static/js/admin/api/api-load.js
+++ b/src/main/resources/static/js/admin/api/api-load.js
@@ -112,6 +112,7 @@
 
         const json = await res.json();
         const data = json.result || json.data || json;
+        const toDatetimeLocal = (value) => value ? String(value).slice(0, 16) : '';
 
         document.querySelector(`[data-target="${formTargetByType[type]}"]`)?.click();
         PickeData.currentContentType = type;
@@ -130,6 +131,7 @@
             PickeData.setValue('content-desc', data.description || '');
             PickeData.setValue('battle-audio-duration', data.audioDuration ?? '');
             PickeData.setValue('battle-status', data.status || 'PENDING');
+            PickeData.setValue('battle-publish-at', toDatetimeLocal(data.publishAt));
             PickeData.setValue('battle-thumbnail-url', data.thumbnailUrl || '');
 
             if (data.thumbnailUrl) {
@@ -202,6 +204,7 @@
         if (type === 'QUIZ') {
             PickeData.setValue('quiz-title', data.title || '');
             PickeData.setValue('quiz-status', data.status || 'PENDING');
+            PickeData.setValue('quiz-publish-at', toDatetimeLocal(data.publishAt));
 
             const options = data.options || [];
             const optionA = options.find((option) => option.label === 'A');
@@ -226,6 +229,7 @@
             PickeData.setValue('poll-title-prefix', data.titlePrefix || '');
             PickeData.setValue('poll-title-suffix', data.titleSuffix || '');
             PickeData.setValue('poll-status', data.status || 'PENDING');
+            PickeData.setValue('poll-publish-at', toDatetimeLocal(data.publishAt));
 
             const optionTargetByLabel = {
                 A: { titleId: 'poll-option-1-title', orderId: 'poll-option-1-display-order' },
@@ -258,6 +262,7 @@
 
 window.updateButtonStates = function (currentStatus) {
     const btnPending = document.getElementById('btn-save-pending');
+    const btnScheduled = document.getElementById('btn-save-scheduled');
     const btnPublish = document.getElementById('btn-save-publish');
     const btnRepublish = document.getElementById('btn-republish-audio');
 
@@ -276,6 +281,10 @@ window.updateButtonStates = function (currentStatus) {
             btnPending.disabled = true;
             btnPending.classList.add('opacity-50', 'cursor-not-allowed', 'bg-gray-200', 'text-gray-400');
         }
+        if (btnScheduled) {
+            btnScheduled.disabled = true;
+            btnScheduled.classList.add('opacity-50', 'cursor-not-allowed', 'bg-gray-200', 'text-gray-400');
+        }
         if (btnRepublish && PickeData.currentContentType === 'BATTLE') {
             btnRepublish.classList.remove('hidden');
         }
@@ -284,6 +293,10 @@ window.updateButtonStates = function (currentStatus) {
         if (btnPending) {
             btnPending.disabled = false;
             btnPending.classList.remove('opacity-50', 'cursor-not-allowed', 'bg-gray-200', 'text-gray-400');
+        }
+        if (btnScheduled) {
+            btnScheduled.disabled = false;
+            btnScheduled.classList.remove('opacity-50', 'cursor-not-allowed', 'bg-gray-200', 'text-gray-400');
         }
     }
 };

--- a/src/main/resources/static/js/admin/api/api-save.js
+++ b/src/main/resources/static/js/admin/api/api-save.js
@@ -2,11 +2,12 @@
     const loader = document.getElementById('global-loader');
     const loaderText = document.getElementById('loader-text');
 
-    const statusFromAction = action === 'PENDING' ? 'PENDING' : 'PUBLISHED';
+    const statusFromAction = action === 'PENDING' || action === 'SCHEDULED' ? 'PENDING' : 'PUBLISHED';
 
     if (loader) {
         if (loaderText) {
             if (action === 'PUBLISHED' || action === 'PUBLISH') loaderText.innerText = '콘텐츠를 발행하는 중입니다...';
+            else if (action === 'SCHEDULED') loaderText.innerText = '콘텐츠를 예약 저장 중입니다...';
             else if (action === 'EDIT') loaderText.innerText = '콘텐츠를 수정하는 중입니다...';
             else loaderText.innerText = '임시 저장 중입니다...';
         }
@@ -40,8 +41,18 @@
         return document.getElementById(inputIdByType[type])?.value || PickeData.currentTargetDate || new Date().toISOString().split('T')[0];
     };
 
+    const getPublishAt = (type) => {
+        const inputIdByType = {
+            BATTLE: 'battle-publish-at',
+            QUIZ: 'quiz-publish-at',
+            POLL: 'poll-publish-at'
+        };
+        const value = document.getElementById(inputIdByType[type])?.value;
+        return value ? value : null;
+    };
+
     const getStatus = (type) => {
-        if (action === 'PENDING') return 'PENDING';
+        if (action === 'PENDING' || action === 'SCHEDULED') return 'PENDING';
         if (action === 'PUBLISHED' || action === 'PUBLISH') return 'PUBLISHED';
 
         const statusInputByType = {
@@ -56,13 +67,18 @@
         const currentType = PickeData.currentContentType;
         const previousStatus = PickeData.currentStatus;
         const targetDate = getTargetDate(currentType);
+        const publishAt = getPublishAt(currentType);
         const resolvedStatus = getStatus(currentType);
         const hasNewBattleImageUploads = currentType === 'BATTLE'
             && !!(PickeData.uploadedFiles.thumbnail || PickeData.uploadedFiles.charA || PickeData.uploadedFiles.charB);
         const shouldUploadAssets = action === 'PUBLISHED' || action === 'PUBLISH' || (action === 'EDIT' && hasNewBattleImageUploads);
-        const shouldUploadLocalDraft = action === 'PENDING';
+        const shouldUploadLocalDraft = action === 'PENDING' || action === 'SCHEDULED';
 
         PickeData.currentTargetDate = targetDate;
+
+        if (action === 'SCHEDULED' && !publishAt) {
+            throw new Error('예약 발행 시각을 입력해 주세요.');
+        }
 
         let thumbnailUrl = PickeData.existingUrls.thumbnail;
         let charAUrl = PickeData.existingUrls.charA;
@@ -110,6 +126,7 @@
                 description: document.getElementById('content-desc')?.value || '',
                 thumbnailUrl: thumbnailUrl || document.getElementById('battle-thumbnail-url')?.value || null,
                 targetDate,
+                publishAt,
                 audioDuration: asIntOrNull(document.getElementById('battle-audio-duration')?.value),
                 tagIds: PickeData.selections.CATEGORY || [],
                 options: [
@@ -144,6 +161,7 @@
             payload = {
                 title: document.getElementById('quiz-title')?.value || '',
                 targetDate,
+                publishAt,
                 status: resolvedStatus,
                 options: [
                     {
@@ -181,6 +199,7 @@
                 titlePrefix: document.getElementById('poll-title-prefix')?.value || '',
                 titleSuffix: document.getElementById('poll-title-suffix')?.value || '',
                 targetDate,
+                publishAt,
                 status: resolvedStatus,
                 options: pollOptions
             };
@@ -329,6 +348,8 @@
         document.getElementById('custom-modal-title').innerText = '완료';
         document.getElementById('custom-modal-message').innerText = action === 'PENDING'
             ? '임시 저장되었습니다.'
+            : action === 'SCHEDULED'
+                ? '예약 저장되었습니다.'
             : action === 'EDIT'
                 ? '수정이 완료되었습니다.'
                 : '발행이 완료되었습니다.';

--- a/src/main/resources/templates/admin/components/form-battle.html
+++ b/src/main/resources/templates/admin/components/form-battle.html
@@ -46,6 +46,11 @@
                 <label class="block text-sm font-bold text-gray-700 mb-2">타겟 날짜 <span class="text-red-500">*</span></label>
                 <input id="battle-target-date" type="date" class="w-full bg-gray-50 border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-black transition-all" />
             </div>
+
+            <div>
+                <label class="block text-sm font-bold text-gray-700 mb-2">예약 발행 시각</label>
+                <input id="battle-publish-at" type="datetime-local" class="w-full bg-gray-50 border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-black transition-all" />
+            </div>
         </div>
     </section>
 

--- a/src/main/resources/templates/admin/components/form-quiz.html
+++ b/src/main/resources/templates/admin/components/form-quiz.html
@@ -16,6 +16,11 @@
                 <input type="date" id="quiz-target-date" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition" />
             </div>
 
+            <div>
+                <label class="block text-[13px] font-bold text-gray-700 mb-2">예약 발행 시각</label>
+                <input type="datetime-local" id="quiz-publish-at" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition" />
+            </div>
+
             <hr class="border-gray-100 my-8">
 
             <div>

--- a/src/main/resources/templates/admin/components/form-vote.html
+++ b/src/main/resources/templates/admin/components/form-vote.html
@@ -21,6 +21,11 @@
                 <input type="date" id="poll-target-date" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition" />
             </div>
 
+            <div>
+                <label class="block text-[13px] font-bold text-gray-700 mb-2">예약 발행 시각</label>
+                <input type="datetime-local" id="poll-publish-at" class="w-full bg-[#FBFBFA] border border-gray-200 rounded-lg p-3 text-sm focus:border-black outline-none transition" />
+            </div>
+
             <hr class="border-gray-100 my-8">
 
             <div>

--- a/src/main/resources/templates/admin/picke-create.html
+++ b/src/main/resources/templates/admin/picke-create.html
@@ -52,6 +52,7 @@
 
 <div class="fixed bottom-0 inset-x-0 bg-white border-t border-gray-200 py-4 px-8 flex justify-end items-center space-x-4 z-40 shadow-lg">
     <button type="button" onclick="saveContent('PENDING')" id="btn-save-pending" class="px-6 py-2.5 border border-gray-300 rounded-lg text-sm font-bold text-gray-600 hover:bg-gray-50">임시저장</button>
+    <button type="button" onclick="saveContent('SCHEDULED')" id="btn-save-scheduled" class="px-6 py-2.5 border border-purple-200 bg-purple-50 rounded-lg text-sm font-bold text-purple-700 hover:bg-purple-100">예약저장</button>
     <button type="button" onclick="saveContent('PUBLISHED')" id="btn-save-publish" class="px-8 py-2.5 bg-black text-white rounded-lg text-sm font-bold hover:bg-gray-800 transition-all">✓ 만들기</button>
     <button id="btn-republish-audio" onclick="confirmRepublish()" class="hidden bg-purple-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-purple-700 transition shadow-md">
         🔊 오디오 재발행

--- a/src/main/resources/templates/admin/picke-list.html
+++ b/src/main/resources/templates/admin/picke-list.html
@@ -68,6 +68,7 @@
                 <th class="px-6 py-4 font-bold w-24">유형</th>
                 <th class="px-6 py-4 font-bold">제목</th>
                 <th class="px-6 py-4 font-bold w-32">상태</th>
+                <th class="px-6 py-4 font-bold w-40">예약 발행</th>
                 <th class="px-6 py-4 font-bold w-32">생성일</th>
                 <th class="px-6 py-4 font-bold w-24 text-center">관리</th>
             </tr>
@@ -292,6 +293,15 @@
                 const date = item.createdAt
                     ? new Date(item.createdAt).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
                     : '-';
+                const publishAt = item.publishAt
+                    ? new Date(item.publishAt).toLocaleString('ko-KR', {
+                        year: 'numeric',
+                        month: '2-digit',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit'
+                    })
+                    : '-';
 
                 const typeBadge = {
                     BATTLE: '<span class="px-2 py-1 bg-purple-100 text-purple-700 text-[10px] font-bold rounded">배틀</span>',
@@ -301,7 +311,9 @@
 
                 const statusBadge = {
                     PUBLISHED: '<span class="flex items-center text-green-600 text-xs font-bold"><span class="w-1.5 h-1.5 rounded-full bg-green-500 mr-1.5"></span>발행</span>',
-                    PENDING: '<span class="flex items-center text-yellow-600 text-xs font-bold"><span class="w-1.5 h-1.5 rounded-full bg-yellow-400 mr-1.5"></span>임시 저장</span>',
+                    PENDING: item.publishAt
+                        ? '<span class="flex items-center text-purple-600 text-xs font-bold"><span class="w-1.5 h-1.5 rounded-full bg-purple-500 mr-1.5"></span>예약 대기</span>'
+                        : '<span class="flex items-center text-yellow-600 text-xs font-bold"><span class="w-1.5 h-1.5 rounded-full bg-yellow-400 mr-1.5"></span>임시 저장</span>',
                     REJECTED: '<span class="flex items-center text-red-500 text-xs font-bold"><span class="w-1.5 h-1.5 rounded-full bg-red-400 mr-1.5"></span>반려</span>',
                     ARCHIVED: '<span class="flex items-center text-gray-400 text-xs font-bold"><span class="w-1.5 h-1.5 rounded-full bg-gray-400 mr-1.5"></span>보관</span>'
                 }[status] ?? `<span class="text-xs font-bold text-gray-500">${status}</span>`;
@@ -320,6 +332,7 @@
                 <td class="px-6 py-4">${typeBadge}</td>
                 <td class="px-6 py-4 font-bold text-gray-900">${title}</td>
                 <td class="px-6 py-4">${statusBadge}</td>
+                <td class="px-6 py-4 text-gray-500 text-xs">${publishAt}</td>
                 <td class="px-6 py-4 text-gray-500 text-xs">${date}</td>
                 <td class="px-6 py-4 text-center">
                     <button class="delete-btn text-gray-400 hover:text-red-500 font-bold text-xs px-2 py-1 border border-gray-200 rounded bg-white hover:border-red-200 transition"

--- a/src/test/java/com/swyp/picke/domain/admin/scheduler/ContentPublishSchedulerIntegrationTest.java
+++ b/src/test/java/com/swyp/picke/domain/admin/scheduler/ContentPublishSchedulerIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.swyp.picke.domain.admin.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.swyp.picke.domain.battle.entity.Battle;
+import com.swyp.picke.domain.battle.enums.BattleCreatorType;
+import com.swyp.picke.domain.battle.enums.BattleStatus;
+import com.swyp.picke.domain.battle.repository.BattleRepository;
+import com.swyp.picke.domain.poll.entity.Poll;
+import com.swyp.picke.domain.poll.enums.PollStatus;
+import com.swyp.picke.domain.poll.repository.PollRepository;
+import com.swyp.picke.domain.quiz.entity.Quiz;
+import com.swyp.picke.domain.quiz.enums.QuizStatus;
+import com.swyp.picke.domain.quiz.repository.QuizRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ContentPublishSchedulerIntegrationTest {
+
+    @Autowired
+    private ContentPublishScheduler contentPublishScheduler;
+
+    @Autowired
+    private BattleRepository battleRepository;
+
+    @Autowired
+    private QuizRepository quizRepository;
+
+    @Autowired
+    private PollRepository pollRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private S3Client s3Client;
+
+    @Test
+    @DisplayName("예약 시간이 지난 콘텐츠만 자동 공개된다")
+    void publishReadyContents_whenPublishAtHasPassed() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDate targetDate = now.toLocalDate();
+
+        Battle dueBattle = battleRepository.save(Battle.builder()
+                .title("예약 배틀")
+                .summary("예약 배틀 요약")
+                .description("예약 배틀 설명")
+                .targetDate(targetDate)
+                .publishAt(now.minusMinutes(1))
+                .status(BattleStatus.PENDING)
+                .creatorType(BattleCreatorType.ADMIN)
+                .build());
+        Battle futureBattle = battleRepository.save(Battle.builder()
+                .title("미래 배틀")
+                .targetDate(targetDate)
+                .publishAt(now.plusDays(1))
+                .status(BattleStatus.PENDING)
+                .creatorType(BattleCreatorType.ADMIN)
+                .build());
+
+        Quiz dueQuiz = quizRepository.save(Quiz.builder()
+                .title("예약 퀴즈")
+                .targetDate(targetDate)
+                .publishAt(now.minusMinutes(1))
+                .status(QuizStatus.PENDING)
+                .build());
+        Quiz futureQuiz = quizRepository.save(Quiz.builder()
+                .title("미래 퀴즈")
+                .targetDate(targetDate)
+                .publishAt(now.plusDays(1))
+                .status(QuizStatus.PENDING)
+                .build());
+
+        Poll duePoll = pollRepository.save(Poll.builder()
+                .titlePrefix("예약 투표")
+                .titleSuffix("선택")
+                .targetDate(targetDate)
+                .publishAt(now.minusMinutes(1))
+                .status(PollStatus.PENDING)
+                .build());
+        Poll futurePoll = pollRepository.save(Poll.builder()
+                .titlePrefix("미래 투표")
+                .titleSuffix("선택")
+                .targetDate(targetDate)
+                .publishAt(now.plusDays(1))
+                .status(PollStatus.PENDING)
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        contentPublishScheduler.openReadyBattles();
+        contentPublishScheduler.openReadyQuizzesAndPolls();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(battleRepository.findById(dueBattle.getId()).orElseThrow().getStatus())
+                .isEqualTo(BattleStatus.PUBLISHED);
+        assertThat(battleRepository.findById(futureBattle.getId()).orElseThrow().getStatus())
+                .isEqualTo(BattleStatus.PENDING);
+        assertThat(quizRepository.findById(dueQuiz.getId()).orElseThrow().getStatus())
+                .isEqualTo(QuizStatus.PUBLISHED);
+        assertThat(quizRepository.findById(futureQuiz.getId()).orElseThrow().getStatus())
+                .isEqualTo(QuizStatus.PENDING);
+        assertThat(pollRepository.findById(duePoll.getId()).orElseThrow().getStatus())
+                .isEqualTo(PollStatus.PUBLISHED);
+        assertThat(pollRepository.findById(futurePoll.getId()).orElseThrow().getStatus())
+                .isEqualTo(PollStatus.PENDING);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #231

## 📝 작업 내용

### ✨ Feat

| 내용 | 파일 |
|------|------|
| 예약 발행 필드/`DTO`/응답 추가 | `AdminBattleCreateRequest.java`, `AdminBattleUpdateRequest.java`, `AdminBattleDetailResponse.java`, `AdminPollCreateRequest.java`, `AdminPollUpdateRequest.java`, `AdminPollDetailResponse.java`, `AdminQuizCreateRequest.java`, `AdminQuizUpdateRequest.java`, `AdminQuizDetailResponse.java`, `Battle.java`, `BattleConverter.java`, `BattleSimpleResponse.java`, `Quiz.java`, `QuizConverter.java`, `QuizSimpleResponse.java`, `Poll.java`, `PollConverter.java`, `PollSimpleResponse.java` |
| 예약 발행 서비스 및 스케줄러 추가 | `ContentPublishScheduler.java`, `AdminPollService.java`, `AdminQuizService.java`, `BattleController.java`, `BattleRepository.java`, `BattleService.java`, `BattleServiceImpl.java`, `QuizRepository.java`, `QuizService.java`, `QuizServiceImpl.java`, `PollRepository.java`, `PollService.java`, `PollServiceImpl.java` |
| 관리자 예약 발행 `UI` 추가 | `api-load.js`, `api-save.js`, `form-battle.html`, `form-quiz.html`, `form-vote.html`, `picke-create.html`, `picke-list.html` |

### 🔨 Chore

| 내용 | 파일 |
|------|------|
| 예약 발행 설정 및 `DB` 마이그레이션 추가 | `application.yml`, `V20260519_01__add_publish_at_to_contents.sql` |
| `Swagger` 노출 범위 및 `@Hidden` `import` 정리 | `SwaggerConfig.java`, `AdminBattleController.java`, `AdminNotificationController.java`, `AdminPollController.java`, `AdminQuizController.java`, `AdminScenarioController.java`, `AdminTagController.java`, `AdminBattleProposalController.java`, `BestCommentSchedulerTestController.java`, `AdMobRewardController.java`, `SearchController.java`, `ShareApiController.java`, `MypageController.java`, `VoteController.java`, `FileUploadController.java`, `ResourceRedirectController.java` |

### 🐛 Fix

| 내용 | 파일 |
|------|------|
| `PostgreSQL` 예약어 `inner` 컬럼 충돌 수정 | `UserTendencyScoreHistory.java` |

### ✅ Test

| 내용 | 파일 |
|------|------|
| 예약 시간이 지난 콘텐츠만 발행되는 통합 테스트 추가 | `ContentPublishSchedulerIntegrationTest.java` |

## 📌 공유 사항
1. `publishAt <= 현재 시간`이고 상태가 `PENDING`인 콘텐츠만 `PUBLISHED`로 전환됩니다.  
2. 퀴즈/투표/배틀 스케줄러는 `Asia/Seoul` 기준 자정에 예약 발행 대상을 확인합니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
#### 예약 발행 스케줄러 테스트 성공
<img width="1769" height="350" alt="스케줄러 테스트 완료" src="https://github.com/user-attachments/assets/b22a8884-7091-4045-9211-62da0df02787" />

#### 로컬 테스트 실행
- 테스트 실행: `./gradlew test --tests "com.swyp.picke.domain.admin.scheduler.ontentPublishSchedulerIntegrationTest"`
- 결과: `BUILD SUCCESSFUL`

## 💬 리뷰 요구사항
1. 예약 발행 `cron` 정책과 `Swagger` 노출 범위가 운영 의도와 맞는지 확인 부탁드립니다.