### PR TITLE
#226 [Feat] 배틀 생성 시 BOT 자동 투표 및 GPT 관점 생성

### DIFF
--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
@@ -72,4 +72,14 @@ public class AdminBattleController {
     ) {
         return ApiResponse.onSuccess(adminBattleService.getBattles(page, size, status));
     }
+
+    @Operation(summary = "기존 배틀에 BOT 관점 자동 생성")
+    @PostMapping("/{battleId}/seed")
+    public ApiResponse<Void> seedBattle(
+            @PathVariable Long battleId,
+            @RequestParam int botCount
+    ) {
+        adminBattleService.seedBattle(battleId, botCount);
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleCreateRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleCreateRequest.java
@@ -13,6 +13,7 @@ public record AdminBattleCreateRequest(
         Integer audioDuration,
         BattleStatus status,
         List<Long> tagIds,
-        List<AdminBattleOptionRequest> options
+        List<AdminBattleOptionRequest> options,
+        int botCount
 ) {}
 

--- a/src/main/java/com/swyp/picke/domain/admin/service/AdminBattleService.java
+++ b/src/main/java/com/swyp/picke/domain/admin/service/AdminBattleService.java
@@ -33,4 +33,8 @@ public class AdminBattleService {
     public Object getBattles(int page, int size, String status) {
         return battleService.getBattles(page, size, status);
     }
+
+    public void seedBattle(Long battleId, int botCount) {
+        battleService.seedBattle(battleId, botCount);
+    }
 }

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleAutoSeedService.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleAutoSeedService.java
@@ -1,0 +1,106 @@
+package com.swyp.picke.domain.battle.service;
+
+import com.swyp.picke.domain.battle.entity.Battle;
+import com.swyp.picke.domain.battle.entity.BattleOption;
+import com.swyp.picke.domain.perspective.entity.Perspective;
+import com.swyp.picke.domain.perspective.repository.PerspectiveRepository;
+import com.swyp.picke.domain.perspective.service.GptPerspectiveGenerationService;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.enums.CreditType;
+import com.swyp.picke.domain.user.enums.UserBattleStep;
+import com.swyp.picke.domain.user.enums.UserRole;
+import com.swyp.picke.domain.user.repository.UserRepository;
+import com.swyp.picke.domain.user.service.CreditService;
+import com.swyp.picke.domain.user.service.UserBattleService;
+import com.swyp.picke.domain.vote.entity.BattleVote;
+import com.swyp.picke.domain.vote.repository.BattleVoteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BattleAutoSeedService {
+
+    private static final int BOT_PERSPECTIVE_COUNT = 5;
+
+    private final UserRepository userRepository;
+    private final BattleVoteRepository battleVoteRepository;
+    private final UserBattleService userBattleService;
+    private final CreditService creditService;
+    private final PerspectiveRepository perspectiveRepository;
+    private final GptPerspectiveGenerationService gptPerspectiveGenerationService;
+
+    @Transactional
+    public void seed(Battle battle, List<BattleOption> options) {
+        if (options.size() < 2) {
+            log.warn("옵션이 2개 미만이라 관점 자동 생성을 건너뜁니다. battleId={}", battle.getId());
+            return;
+        }
+
+        List<User> bots = userRepository.findAllByRole(UserRole.BOT);
+        if (bots.isEmpty()) {
+            log.warn("BOT 계정이 없어 관점 자동 생성을 건너뜁니다. battleId={}", battle.getId());
+            return;
+        }
+
+        List<User> selectedBots = new ArrayList<>(bots);
+        Collections.shuffle(selectedBots);
+        if (selectedBots.size() > BOT_PERSPECTIVE_COUNT) {
+            selectedBots = selectedBots.subList(0, BOT_PERSPECTIVE_COUNT);
+        }
+
+        BattleOption optionA = options.get(0);
+        BattleOption optionB = options.get(1);
+
+        // (2,3) 또는 (3,2) 랜덤 결정
+        int optionACount = ThreadLocalRandom.current().nextBoolean() ? 2 : 3;
+
+        for (int i = 0; i < selectedBots.size(); i++) {
+            User bot = selectedBots.get(i);
+            BattleOption postOption = i < optionACount ? optionA : optionB;
+            BattleOption otherOption = postOption == optionA ? optionB : optionA;
+
+            // preVoteOption: 50% 확률로 같거나 다른 옵션
+            BattleOption preOption = ThreadLocalRandom.current().nextBoolean() ? postOption : otherOption;
+
+            try {
+                BattleVote vote = BattleVote.builder()
+                        .user(bot)
+                        .battle(battle)
+                        .preVoteOption(preOption)
+                        .postVoteOption(postOption)
+                        .isTtsListened(false)
+                        .build();
+                battleVoteRepository.save(vote);
+
+                creditService.addCredit(bot.getId(), CreditType.BATTLE_VOTE, vote.getId());
+
+                userBattleService.upsertStep(bot, battle, UserBattleStep.COMPLETED);
+
+                battle.addParticipant();
+
+                String content = gptPerspectiveGenerationService.generate(battle, postOption);
+
+                Perspective perspective = Perspective.builder()
+                        .battle(battle)
+                        .user(bot)
+                        .option(postOption)
+                        .content(content)
+                        .build();
+                perspective.publish();
+                perspectiveRepository.save(perspective);
+
+            } catch (Exception e) {
+                log.error("봇 관점 자동 생성 실패. botId={}, battleId={}", bot.getId(), battle.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleAutoSeedService.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleAutoSeedService.java
@@ -29,8 +29,6 @@ import java.util.concurrent.ThreadLocalRandom;
 @RequiredArgsConstructor
 public class BattleAutoSeedService {
 
-    private static final int BOT_PERSPECTIVE_COUNT = 5;
-
     private final UserRepository userRepository;
     private final BattleVoteRepository battleVoteRepository;
     private final UserBattleService userBattleService;
@@ -39,7 +37,7 @@ public class BattleAutoSeedService {
     private final GptPerspectiveGenerationService gptPerspectiveGenerationService;
 
     @Transactional
-    public void seed(Battle battle, List<BattleOption> options) {
+    public void seed(Battle battle, List<BattleOption> options, int botCount) {
         if (options.size() < 2) {
             log.warn("옵션이 2개 미만이라 관점 자동 생성을 건너뜁니다. battleId={}", battle.getId());
             return;
@@ -53,15 +51,14 @@ public class BattleAutoSeedService {
 
         List<User> selectedBots = new ArrayList<>(bots);
         Collections.shuffle(selectedBots);
-        if (selectedBots.size() > BOT_PERSPECTIVE_COUNT) {
-            selectedBots = selectedBots.subList(0, BOT_PERSPECTIVE_COUNT);
-        }
+        int n = Math.min(botCount, selectedBots.size());
+        selectedBots = selectedBots.subList(0, n);
 
         BattleOption optionA = options.get(0);
         BattleOption optionB = options.get(1);
 
-        // (2,3) 또는 (3,2) 랜덤 결정
-        int optionACount = ThreadLocalRandom.current().nextBoolean() ? 2 : 3;
+        int half = n / 2;
+        int optionACount = (n % 2 == 0) ? half : (ThreadLocalRandom.current().nextBoolean() ? half : half + 1);
 
         for (int i = 0; i < selectedBots.size(); i++) {
             User bot = selectedBots.get(i);

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleService.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleService.java
@@ -53,4 +53,6 @@ public interface BattleService {
     AdminBattleDetailResponse updateBattle(Long battleId, AdminBattleUpdateRequest request);
 
     AdminBattleDeleteResponse deleteBattle(Long battleId);
+
+    void seedBattle(Long battleId, int botCount);
 }

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -346,7 +346,7 @@ public class BattleServiceImpl implements BattleService {
                         Collectors.mapping(BattleOptionTag::getTag, Collectors.toList())
                 ));
 
-        battleAutoSeedService.seed(battle, savedOptions);
+        battleAutoSeedService.seed(battle, savedOptions, request.botCount());
 
         return battleConverter.toAdminDetailResponse(battle, getTagsByBattle(battle), savedOptions, optionTagsMap);
     }
@@ -469,6 +469,15 @@ public class BattleServiceImpl implements BattleService {
         Battle battle = findById(battleId);
         battle.delete();
         return new AdminBattleDeleteResponse(true, LocalDateTime.now());
+    }
+
+    @Override
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
+    public void seedBattle(Long battleId, int botCount) {
+        Battle battle = findById(battleId);
+        List<BattleOption> options = battleOptionRepository.findByBattle(battle);
+        battleAutoSeedService.seed(battle, options, botCount);
     }
 
     private List<TodayBattleResponse> convertToTodayResponses(List<Battle> battles) {

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -72,6 +72,7 @@ public class BattleServiceImpl implements BattleService {
     private final S3UploadService s3UploadService;
     private final LocalDraftFileStorageService localDraftFileStorageService;
     private final UserBattleService userBattleService;
+    private final BattleAutoSeedService battleAutoSeedService;
 
     @Override
     public Battle findById(Long battleId) {
@@ -344,6 +345,8 @@ public class BattleServiceImpl implements BattleService {
                         bot -> bot.getBattleOption().getId(),
                         Collectors.mapping(BattleOptionTag::getTag, Collectors.toList())
                 ));
+
+        battleAutoSeedService.seed(battle, savedOptions);
 
         return battleConverter.toAdminDetailResponse(battle, getTagsByBattle(battle), savedOptions, optionTagsMap);
     }

--- a/src/main/java/com/swyp/picke/domain/perspective/service/GptPerspectiveGenerationService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/GptPerspectiveGenerationService.java
@@ -1,0 +1,68 @@
+package com.swyp.picke.domain.perspective.service;
+
+import com.swyp.picke.domain.battle.entity.Battle;
+import com.swyp.picke.domain.battle.entity.BattleOption;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class GptPerspectiveGenerationService {
+
+    private static final String SYSTEM_PROMPT =
+            "당신은 철학적 토론 배틀에서 특정 입장을 지지하는 관점을 작성하는 AI입니다. " +
+            "주어진 배틀 주제와 옵션 정보를 바탕으로, 해당 옵션을 지지하는 자신만의 관점을 한국어로 100자 이내로 작성하세요. " +
+            "자연스럽고 간결하며, 일반인이 직접 쓴 것처럼 작성하세요. 관점 텍스트만 출력하세요.";
+
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+    private static final int READ_TIMEOUT_MS = 15000;
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    @Value("${openai.url}")
+    private String openaiUrl;
+
+    @Value("${openai.model}")
+    private String model;
+
+    public String generate(Battle battle, BattleOption option) {
+        String userPrompt = String.format(
+                "배틀 제목: %s\n배틀 설명: %s\n지지할 옵션: %s\n해당 옵션의 입장: %s",
+                battle.getTitle(), battle.getDescription(), option.getTitle(), option.getStance()
+        );
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        RestClient restClient = RestClient.builder().requestFactory(factory).build();
+
+        Map<String, Object> requestBody = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", SYSTEM_PROMPT),
+                        Map.of("role", "user", "content", userPrompt)
+                ),
+                "max_tokens", 200
+        );
+
+        Map response = restClient.post()
+                .uri(openaiUrl)
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .retrieve()
+                .body(Map.class);
+
+        List choices = (List) response.get("choices");
+        Map choice = (Map) choices.get(0);
+        Map message = (Map) choice.get("message");
+        return ((String) message.get("content")).trim();
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/user/enums/UserRole.java
+++ b/src/main/java/com/swyp/picke/domain/user/enums/UserRole.java
@@ -2,5 +2,6 @@ package com.swyp.picke.domain.user.enums;
 
 public enum UserRole {
     USER,
-    ADMIN
+    ADMIN,
+    BOT
 }

--- a/src/main/java/com/swyp/picke/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/swyp/picke/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.swyp.picke.domain.user.repository;
 
 import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.enums.UserRole;
 import com.swyp.picke.domain.user.enums.UserStatus;
 import java.util.List;
 import java.util.Optional;
@@ -26,4 +27,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     int decrementCreditIfEnough(@Param("id") Long id, @Param("amount") int amount);
 
     List<User> findAllByStatus(UserStatus status);
+
+    List<User> findAllByRole(UserRole role);
 }

--- a/src/main/resources/db/migration/V20260512_01__add_bot_role.sql
+++ b/src/main/resources/db/migration/V20260512_01__add_bot_role.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP CONSTRAINT users_role_check;
+ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('USER', 'ADMIN', 'BOT'));


### PR DESCRIPTION
## #️ 연관된 이슈
  - #226

  ## 📝 작업 내용

  ### ✨ Feat
  | 내용 | 파일 |
  |------|------|
  | 배틀 생성 시 BOT 자동 투표 및 GPT 관점 생성 서비스 구현 | `BattleAutoSeedService.java` |
  | OpenAI API 연동 GPT 관점 자동 생성 서비스 구현 | `GptPerspectiveGenerationService.java` |
  | 기존 배틀에 BOT seed 실행 API 추가 (`POST /api/v1/admin/battles/{battleId}/seed`) | `AdminBattleController.java`, `AdminBattleService.java` |
  | 배틀 생성 요청에 `botCount` 파라미터 추가 (BOT 수 동적 지정) | `AdminBattleCreateRequest.java` |
  | BOT role DB 제약 조건 추가 | `V20260512_01__add_bot_role.sql` |

  ### ♻️ Refactor
  | 내용 | 파일 |
  |------|------|
  | BOT 수 하드코딩(5) → `botCount` 파라미터로 동적 처리, 분배 로직을 `n/2` 기준으로 변경 | `BattleAutoSeedService.java` |
  | `UserRole` enum에 `BOT` 추가 | `UserRole.java` |
  | `findAllByRole()` 메서드 추가 | `UserRepository.java` |
  | `seedBattle()` 인터페이스 및 구현체 추가 | `BattleService.java`, `BattleServiceImpl.java` |

  ## 📌 공유 사항
  > 1. BOT 계정(`role = 'BOT'`)이 DB에 사전 등록되어 있어야 동작합니다. 노션 환경 설정 문서의 BOT 계정 INSERT SQL을 참고해주세요.
  > 2. `OPENAI_API_KEY`, `OPENAI_URL`, `OPENAI_MODEL` 환경변수가 세팅되어 있어야 GPT 관점 생성이 동작합니다.

  ## ✅ 체크리스트
  - [x] Reviewer에 팀원들을 선택했나요?
  - [x] Assignees에 본인을 선택했나요?
  - [x] 컨벤션에 맞는 Type을 선택했나요?
  - [x] Development에 이슈를 연동했나요?
  - [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [x] 컨벤션을 지키고 있나요?
  - [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [x] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷

  ## 💬 리뷰 요구사항
  > 1. BOT 관점 생성 실패 시 해당 BOT만 건너뛰고 계속 진행하는 방식(`try-catch` per bot)으로 구현했는데, 전체 트랜잭션을 롤백하는 방식과 비교해 적절한 선택인지 의견 부탁드립니다.
