### PR TITLE
#237 [Refactor] 관점 옵션 표시 및 필터 응답 구조 개선

### DIFF
--- a/docs/api-specs/perspectives-api.md
+++ b/docs/api-specs/perspectives-api.md
@@ -96,7 +96,7 @@
 - 파라미터        |    타입    | 필수 | 설명
 - cursor        |   string  |  X  | 커서 페이지네이션
 -  size         |   number  |  X  | 기본값 20 (임의 설정했음)
--  option_label |   string  |  X  | A or B 투표 옵션 필터
+-  optionId |   number  |  X  | 옵션 ID 필터
 
 
 #### 성공 응답 `200 OK`
@@ -115,8 +115,8 @@
         },
         "option": {
           "option_id": "option_A",
-          "label": "A",
-          "title": "찬성"
+          "label": "예술이 아니다",
+          "title": "예술이 아니다"
         },
         "content": "자기결정권은 가장 기본적인 인권이라고 생각해요.",
         "like_count": 12,

--- a/docs/api-specs/vote-api.md
+++ b/docs/api-specs/vote-api.md
@@ -89,3 +89,5 @@
 - Poll 투표 응답: `PollVoteResponse`
   - `selectedOptionId`, `totalCount`, `stats[].ratio` 포함
 - 배틀 투표 응답: `VoteResultResponse`, `VoteStatsResponse`, `MyVoteResponse`
+  - `VoteStatsResponse.options[].imageUrl`은 철학자 이미지 리소스 리다이렉트 URL을 반환
+  - `MyVoteResponse.*Vote.label`은 A/B가 아니라 옵션 `title`과 같은 의견 문구를 반환

--- a/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
@@ -6,6 +6,7 @@ import com.swyp.picke.domain.battle.dto.response.*;
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
 import com.swyp.picke.domain.battle.enums.BattleCreatorType;
+import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.tag.entity.Tag;
 import com.swyp.picke.domain.tag.enums.TagType;
 import com.swyp.picke.domain.user.entity.User;
@@ -84,7 +85,7 @@ public class BattleConverter {
                 battle.getStatus(),
                 battle.getCreatorType(),
                 toTagResponses(tags, null),
-                toOptionResponses(options, optionTagsMap),
+                toOptionResponses(options, optionTagsMap, false),
                 battle.getCreatedAt(),
                 battle.getUpdatedAt()
         );
@@ -103,7 +104,7 @@ public class BattleConverter {
                 participantsCount == null ? 0L : participantsCount,
                 battle.getAudioDuration() == null ? 0 : battle.getAudioDuration(),
                 toTagResponses(tags, null),
-                toOptionResponses(options, optionTagsMap)
+                toOptionResponses(options, optionTagsMap, true)
         );
 
         return new BattleUserDetailResponse(
@@ -130,7 +131,11 @@ public class BattleConverter {
         return new BattleScenarioResponse(battle.getTitle(), profiles);
     }
 
-    private List<BattleOptionResponse> toOptionResponses(List<BattleOption> options, Map<Long, List<Tag>> optionTagsMap) {
+    private List<BattleOptionResponse> toOptionResponses(
+            List<BattleOption> options,
+            Map<Long, List<Tag>> optionTagsMap,
+            boolean useDisplayLabel
+    ) {
         if (options == null) return List.of();
         return options.stream()
                 .sorted(OPTION_SORTER)
@@ -138,7 +143,9 @@ public class BattleConverter {
                     List<Tag> optionTags = optionTagsMap.getOrDefault(option.getId(), List.of());
                     return new BattleOptionResponse(
                             option.getId(),
-                            option.getLabel(),
+                            useDisplayLabel
+                                    ? BattleOptionDisplay.opinion(option)
+                                    : (option.getLabel() == null ? null : option.getLabel().name()),
                             option.getTitle(),
                             option.getStance(),
                             option.getRepresentative(),

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleOptionResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleOptionResponse.java
@@ -1,12 +1,10 @@
 package com.swyp.picke.domain.battle.dto.response;
 
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
-
 import java.util.List;
 
 public record BattleOptionResponse(
         Long optionId,
-        BattleOptionLabel label,
+        String label,
         String title,
         String stance,
         String representative,

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/OptionStatResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/OptionStatResponse.java
@@ -1,6 +1,7 @@
 package com.swyp.picke.domain.battle.dto.response;
 
 import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
+
 /**
  * 유저 - 옵션별 실시간 통계
  * 역할: 각 선택지별로 몇 명이 선택했는지, 퍼센트(%)는 얼마인지 담습니다.

--- a/src/main/java/com/swyp/picke/domain/battle/util/BattleOptionDisplay.java
+++ b/src/main/java/com/swyp/picke/domain/battle/util/BattleOptionDisplay.java
@@ -1,0 +1,20 @@
+package com.swyp.picke.domain.battle.util;
+
+import com.swyp.picke.domain.battle.entity.BattleOption;
+
+public final class BattleOptionDisplay {
+
+    private BattleOptionDisplay() {
+    }
+
+    public static String opinion(BattleOption option) {
+        if (option == null) {
+            return null;
+        }
+        String title = option.getTitle();
+        if (title != null && !title.isBlank()) {
+            return title;
+        }
+        return option.getLabel() == null ? null : option.getLabel().name();
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/perspective/controller/PerspectiveCommentController.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/controller/PerspectiveCommentController.java
@@ -51,7 +51,7 @@ public class PerspectiveCommentController {
         return ApiResponse.onSuccess(commentService.getComments(perspectiveId, userId, cursor, size));
     }
 
-    @Operation(summary = "댓글 목록 조회 (옵션 라벨)", description = "특정 관점의 댓글 목록을 커서 기반 페이지네이션으로 조회하며, stance를 투표한 옵션 라벨(A/B)로 반환합니다.")
+    @Operation(summary = "댓글 목록 조회 (옵션 의견)", description = "특정 관점의 댓글 목록을 커서 기반 페이지네이션으로 조회하며, stance를 투표한 옵션 의견 문구로 반환합니다.")
     @GetMapping("/perspectives/{perspectiveId}/comments/labeled")
     public ApiResponse<CommentListResponse> getCommentsWithLabel(
             @PathVariable Long perspectiveId,

--- a/src/main/java/com/swyp/picke/domain/perspective/controller/PerspectiveController.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/controller/PerspectiveController.java
@@ -57,10 +57,10 @@ public class PerspectiveController {
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size,
-            @RequestParam(required = false) String optionLabel,
+            @RequestParam(required = false) Long optionId,
             @RequestParam(required = false, defaultValue = "latest") String sort
     ) {
-        return ApiResponse.onSuccess(perspectiveService.getPerspectives(battleId, userId, cursor, size, optionLabel, sort));
+        return ApiResponse.onSuccess(perspectiveService.getPerspectives(battleId, userId, cursor, size, optionId, sort));
     }
 
     @Operation(summary = "내 관점 조회", description = "해당 배틀에서 본인이 작성한 관점을 조회합니다.")

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
@@ -2,6 +2,7 @@ package com.swyp.picke.domain.perspective.service;
 
 import com.swyp.picke.domain.battle.entity.BattleOption;
 import com.swyp.picke.domain.battle.service.BattleService;
+import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.perspective.dto.request.CreateCommentRequest;
 import com.swyp.picke.domain.perspective.dto.request.UpdateCommentRequest;
 import com.swyp.picke.domain.perspective.dto.response.CommentListResponse;
@@ -65,7 +66,7 @@ public class PerspectiveCommentService {
         Long postVoteOptionId = BattleVoteService.findPostVoteOptionId(perspective.getBattle().getId(), userId);
         String stance = null;
         if (postVoteOptionId != null) {
-            stance = battleService.findOptionById(postVoteOptionId).getLabel().name();
+            stance = BattleOptionDisplay.opinion(battleService.findOptionById(postVoteOptionId));
         }
         return new CreateCommentResponse(
                 comment.getId(),
@@ -100,7 +101,7 @@ public class PerspectiveCommentService {
                     String stance = null;
                     if (postVoteOptionId != null) {
                         BattleOption option = battleService.findOptionById(postVoteOptionId);
-                        stance = option.getLabel().name();
+                        stance = BattleOptionDisplay.opinion(option);
                     }
                     boolean isLiked = commentLikeRepository.existsByCommentAndUserId(c, userId);
                     return new CommentListResponse.Item(
@@ -144,7 +145,7 @@ public class PerspectiveCommentService {
                     String stance = null;
                     if (postVoteOptionId != null) {
                         BattleOption option = battleService.findOptionById(postVoteOptionId);
-                        stance = option.getLabel().name();
+                        stance = BattleOptionDisplay.opinion(option);
                     }
                     boolean isLiked = commentLikeRepository.existsByCommentAndUserId(c, userId);
                     return new CommentListResponse.Item(

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
@@ -2,8 +2,8 @@ package com.swyp.picke.domain.perspective.service;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.battle.service.BattleService;
+import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.perspective.enums.PerspectiveStatus;
 import com.swyp.picke.domain.user.entity.User;
 import com.swyp.picke.domain.user.repository.UserRepository;
@@ -62,7 +62,7 @@ public class PerspectiveService {
         return new PerspectiveDetailResponse(
                 perspective.getId(),
                 new PerspectiveDetailResponse.UserSummary(user.userTag(), user.nickname(), user.characterType(), characterImageUrl),
-                new PerspectiveDetailResponse.OptionSummary(option.getId(), option.getLabel().name(), option.getTitle(), option.getStance()),
+                new PerspectiveDetailResponse.OptionSummary(option.getId(), BattleOptionDisplay.opinion(option), option.getTitle(), option.getStance()),
                 perspective.getContent(),
                 perspective.getLikeCount(),
                 perspective.getCommentCount(),
@@ -97,8 +97,8 @@ public class PerspectiveService {
         return new CreatePerspectiveResponse(saved.getId(), saved.getStatus(), saved.getCreatedAt());
     }
 
-    public PerspectiveListResponse getPerspectives(Long battleId, Long userId, String cursor, Integer size, String optionLabel, String sort) {
-        battleService.findById(battleId);
+    public PerspectiveListResponse getPerspectives(Long battleId, Long userId, String cursor, Integer size, Long optionId, String sort) {
+        Battle battle = battleService.findById(battleId);
 
         int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
         PageRequest pageable = PageRequest.of(0, pageSize);
@@ -106,9 +106,8 @@ public class PerspectiveService {
         boolean isPopular = "popular".equalsIgnoreCase(sort);
         List<Perspective> perspectives;
 
-        if (optionLabel != null) {
-            BattleOptionLabel label = BattleOptionLabel.valueOf(optionLabel.toUpperCase());
-            BattleOption option = battleService.findOptionByBattleIdAndLabel(battleId, label);
+        if (optionId != null) {
+            BattleOption option = findFilterOption(battle, optionId);
             perspectives = isPopular
                     ? perspectiveRepository.findByBattleIdAndOptionIdAndStatusOrderByLikeCountDescCreatedAtDesc(battleId, option.getId(), PerspectiveStatus.PUBLISHED, pageable)
                     : cursor == null
@@ -131,7 +130,7 @@ public class PerspectiveService {
                     return new PerspectiveListResponse.Item(
                             p.getId(),
                             new PerspectiveListResponse.UserSummary(user.userTag(), user.nickname(), user.characterType(), characterImageUrl),
-                            new PerspectiveListResponse.OptionSummary(option.getId(), option.getLabel().name(), option.getTitle(), option.getStance()),
+                            new PerspectiveListResponse.OptionSummary(option.getId(), BattleOptionDisplay.opinion(option), option.getTitle(), option.getStance()),
                             p.getContent(),
                             p.getLikeCount(),
                             p.getCommentCount(),
@@ -180,7 +179,7 @@ public class PerspectiveService {
         return new MyPerspectiveResponse(
                 perspective.getId(),
                 new MyPerspectiveResponse.UserSummary(user.userTag(), user.nickname(), user.characterType(), characterImageUrl),
-                new MyPerspectiveResponse.OptionSummary(option.getId(), option.getLabel().name(), option.getTitle(), option.getStance()),
+                new MyPerspectiveResponse.OptionSummary(option.getId(), BattleOptionDisplay.opinion(option), option.getTitle(), option.getStance()),
                 perspective.getContent(),
                 perspective.getLikeCount(),
                 perspective.getCommentCount(),
@@ -210,6 +209,14 @@ public class PerspectiveService {
         if (!perspective.getUser().getId().equals(userId)) {
             throw new CustomException(ErrorCode.PERSPECTIVE_FORBIDDEN);
         }
+    }
+
+    private BattleOption findFilterOption(Battle battle, Long optionId) {
+        BattleOption option = battleService.findOptionById(optionId);
+        if (option.getBattle() == null || !battle.getId().equals(option.getBattle().getId())) {
+            throw new CustomException(ErrorCode.BATTLE_OPTION_NOT_FOUND);
+        }
+        return option;
     }
 
     private String resolveCharacterImageUrl(String characterType) {

--- a/src/main/java/com/swyp/picke/domain/vote/converter/VoteConverter.java
+++ b/src/main/java/com/swyp/picke/domain/vote/converter/VoteConverter.java
@@ -1,6 +1,7 @@
 package com.swyp.picke.domain.vote.converter;
 
 import com.swyp.picke.domain.battle.entity.BattleOption;
+import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.user.enums.UserBattleStep;
 import com.swyp.picke.domain.vote.dto.response.MyVoteResponse;
 import com.swyp.picke.domain.vote.dto.response.VoteResultResponse;
@@ -41,6 +42,6 @@ public class VoteConverter {
         if (option == null) {
             return null;
         }
-        return new MyVoteResponse.OptionInfo(option.getId(), option.getLabel().name(), option.getTitle());
+        return new MyVoteResponse.OptionInfo(option.getId(), BattleOptionDisplay.opinion(option), option.getTitle());
     }
 }

--- a/src/main/java/com/swyp/picke/domain/vote/dto/response/VoteStatsResponse.java
+++ b/src/main/java/com/swyp/picke/domain/vote/dto/response/VoteStatsResponse.java
@@ -10,8 +10,7 @@ public record VoteStatsResponse(
 ) {
     public record OptionStat(
             Long optionId,
-            String label,
-            String title,
+            String imageUrl,
             long voteCount,
             double ratio
     ) {}

--- a/src/main/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImpl.java
@@ -21,6 +21,8 @@ import com.swyp.picke.domain.vote.repository.BattleVoteRepository;
 import com.swyp.picke.domain.vote.sse.VoteUpdatedEvent;
 import com.swyp.picke.global.common.exception.CustomException;
 import com.swyp.picke.global.common.exception.ErrorCode;
+import com.swyp.picke.global.infra.s3.enums.FileCategory;
+import com.swyp.picke.global.infra.s3.util.ResourceUrlProvider;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -45,6 +47,7 @@ public class BattleVoteServiceImpl implements BattleVoteService {
     private final UserBattleService userBattleService;
     private final CreditService creditService;
     private final ApplicationEventPublisher eventPublisher;
+    private final ResourceUrlProvider urlProvider;
 
     @Override
     public BattleOption findPreVoteOption(Long battleId, Long userId) {
@@ -82,8 +85,7 @@ public class BattleVoteServiceImpl implements BattleVoteService {
                             : 0.0;
                     return new VoteStatsResponse.OptionStat(
                             option.getId(),
-                            option.getLabel().name(),
-                            option.getTitle(),
+                            urlProvider.getImageUrl(FileCategory.PHILOSOPHER, option.getImageUrl()),
                             count,
                             ratio
                     );

--- a/src/test/java/com/swyp/picke/domain/oauth/service/OAuthServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/oauth/service/OAuthServiceTest.java
@@ -2,6 +2,7 @@ package com.swyp.picke.domain.oauth.service;
 
 import com.swyp.picke.domain.oauth.client.GoogleOAuthClient;
 import com.swyp.picke.domain.oauth.client.KakaoOAuthClient;
+import com.swyp.picke.domain.oauth.client.AppleOAuthClient;
 import com.swyp.picke.domain.oauth.dto.LoginRequest;
 import com.swyp.picke.domain.oauth.dto.LoginResponse;
 import com.swyp.picke.domain.oauth.dto.OAuthUserInfo;
@@ -41,6 +42,7 @@ class OAuthServiceTest {
 
     @Mock private KakaoOAuthClient kakaoOAuthClient;
     @Mock private GoogleOAuthClient googleOAuthClient;
+    @Mock private AppleOAuthClient appleOAuthClient;
     @Mock private UserRepository userRepository;
     @Mock private UserSocialAccountRepository socialAccountRepository;
     @Mock private AuthRefreshTokenRepository refreshTokenRepository;
@@ -57,7 +59,7 @@ class OAuthServiceTest {
     void setUp() {
         // 수동 주입으로 안정성 확보
         authService = new AuthService(
-                kakaoOAuthClient, googleOAuthClient, userRepository,
+                kakaoOAuthClient, googleOAuthClient, appleOAuthClient, userRepository,
                 socialAccountRepository, refreshTokenRepository,
                 userProfileRepository, userSettingsRepository, userTendencyScoreRepository,
                 userWithdrawalRepository,
@@ -69,7 +71,7 @@ class OAuthServiceTest {
     void login_카카오_기존유저_로그인_성공() {
         // 1. 준비 (Given)
         String provider = "KAKAO";
-        LoginRequest request = new LoginRequest("auth-code", "redirect-uri");
+        LoginRequest request = new LoginRequest("auth-code", "redirect-uri", null);
         OAuthUserInfo userInfo = new OAuthUserInfo("kakao_123", "bex@test.com", "profile_url");
 
         // 유저 엔티티에 ID가 없으므로 식별자 필드만 세팅 (UserTag 등)
@@ -104,7 +106,7 @@ class OAuthServiceTest {
     @Test
     void login_구글_신규유저_기본_user_domain_초기화() {
         String provider = "GOOGLE";
-        LoginRequest request = new LoginRequest("auth-code", "redirect-uri");
+        LoginRequest request = new LoginRequest("auth-code", "redirect-uri", null);
         OAuthUserInfo userInfo = new OAuthUserInfo("google_123", "new@test.com", "profile_url");
 
         User savedUser = User.builder()

--- a/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentServiceTest.java
@@ -1,0 +1,138 @@
+package com.swyp.picke.domain.perspective.service;
+
+import com.swyp.picke.domain.battle.entity.Battle;
+import com.swyp.picke.domain.battle.entity.BattleOption;
+import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
+import com.swyp.picke.domain.battle.enums.BattleStatus;
+import com.swyp.picke.domain.battle.service.BattleService;
+import com.swyp.picke.domain.perspective.dto.response.CommentListResponse;
+import com.swyp.picke.domain.perspective.entity.Perspective;
+import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
+import com.swyp.picke.domain.perspective.repository.CommentLikeRepository;
+import com.swyp.picke.domain.perspective.repository.PerspectiveCommentRepository;
+import com.swyp.picke.domain.perspective.repository.PerspectiveRepository;
+import com.swyp.picke.domain.user.dto.response.UserSummary;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.enums.UserRole;
+import com.swyp.picke.domain.user.enums.UserStatus;
+import com.swyp.picke.domain.user.repository.UserRepository;
+import com.swyp.picke.domain.user.service.UserService;
+import com.swyp.picke.domain.vote.service.BattleVoteService;
+import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PerspectiveCommentServiceTest {
+
+    @Mock
+    private PerspectiveRepository perspectiveRepository;
+
+    @Mock
+    private PerspectiveCommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Mock
+    private UserService userQueryService;
+
+    @Mock
+    private BattleVoteService battleVoteService;
+
+    @Mock
+    private BattleService battleService;
+
+    @Mock
+    private S3PresignedUrlService s3PresignedUrlService;
+
+    @InjectMocks
+    private PerspectiveCommentService commentService;
+
+    @Test
+    @DisplayName("댓글 목록 응답의 stance는 A/B 대신 투표한 의견 문구를 반환한다")
+    void getComments_returns_option_opinion_as_stance() {
+        User writer = user(1L);
+        User commenter = user(2L);
+        Battle battle = battle(100L);
+        BattleOption perspectiveOption = option(10L, battle, BattleOptionLabel.B, "예술이다");
+        BattleOption votedOption = option(11L, battle, BattleOptionLabel.A, "예술이 아니다");
+        Perspective perspective = Perspective.builder()
+                .battle(battle)
+                .user(writer)
+                .option(perspectiveOption)
+                .content("관점 내용")
+                .build();
+        ReflectionTestUtils.setField(perspective, "id", 1000L);
+        PerspectiveComment comment = PerspectiveComment.builder()
+                .perspective(perspective)
+                .user(commenter)
+                .content("댓글 내용")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", 2000L);
+
+        when(perspectiveRepository.findById(1000L)).thenReturn(Optional.of(perspective));
+        when(commentRepository.findByPerspectiveOrderByCreatedAtDesc(eq(perspective), any(Pageable.class)))
+                .thenReturn(List.of(comment));
+        when(userQueryService.findSummaryById(2L)).thenReturn(new UserSummary("user-2", "nick", "OWL"));
+        when(s3PresignedUrlService.generatePresignedUrl(anyString())).thenReturn("character-url");
+        when(battleVoteService.findPostVoteOptionId(100L, 2L)).thenReturn(11L);
+        when(battleService.findOptionById(11L)).thenReturn(votedOption);
+
+        CommentListResponse response = commentService.getComments(1000L, 1L, null, null);
+
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().getFirst().stance()).isEqualTo("예술이 아니다");
+    }
+
+    private Battle battle(Long id) {
+        Battle battle = Battle.builder()
+                .title("battle")
+                .summary("summary")
+                .targetDate(LocalDate.now())
+                .status(BattleStatus.PUBLISHED)
+                .build();
+        ReflectionTestUtils.setField(battle, "id", id);
+        return battle;
+    }
+
+    private BattleOption option(Long id, Battle battle, BattleOptionLabel label, String title) {
+        BattleOption option = BattleOption.builder()
+                .battle(battle)
+                .label(label)
+                .title(title)
+                .stance("stance")
+                .build();
+        ReflectionTestUtils.setField(option, "id", id);
+        return option;
+    }
+
+    private User user(Long id) {
+        User user = User.builder()
+                .userTag("user-" + id)
+                .nickname("nick")
+                .role(UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveServiceTest.java
@@ -1,0 +1,125 @@
+package com.swyp.picke.domain.perspective.service;
+
+import com.swyp.picke.domain.battle.entity.Battle;
+import com.swyp.picke.domain.battle.entity.BattleOption;
+import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
+import com.swyp.picke.domain.battle.enums.BattleStatus;
+import com.swyp.picke.domain.battle.service.BattleService;
+import com.swyp.picke.domain.perspective.dto.response.PerspectiveDetailResponse;
+import com.swyp.picke.domain.perspective.entity.Perspective;
+import com.swyp.picke.domain.perspective.repository.PerspectiveCommentRepository;
+import com.swyp.picke.domain.perspective.repository.PerspectiveLikeRepository;
+import com.swyp.picke.domain.perspective.repository.PerspectiveRepository;
+import com.swyp.picke.domain.user.dto.response.UserSummary;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.enums.UserRole;
+import com.swyp.picke.domain.user.enums.UserStatus;
+import com.swyp.picke.domain.user.repository.UserRepository;
+import com.swyp.picke.domain.user.service.UserService;
+import com.swyp.picke.domain.vote.service.BattleVoteService;
+import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PerspectiveServiceTest {
+
+    @Mock
+    private PerspectiveRepository perspectiveRepository;
+
+    @Mock
+    private PerspectiveCommentRepository perspectiveCommentRepository;
+
+    @Mock
+    private PerspectiveLikeRepository perspectiveLikeRepository;
+
+    @Mock
+    private BattleService battleService;
+
+    @Mock
+    private BattleVoteService battleVoteService;
+
+    @Mock
+    private UserService userQueryService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GptModerationService gptModerationService;
+
+    @Mock
+    private S3PresignedUrlService s3PresignedUrlService;
+
+    @InjectMocks
+    private PerspectiveService perspectiveService;
+
+    @Test
+    @DisplayName("관점 상세 응답의 옵션 label은 A/B 대신 의견 문구를 반환한다")
+    void getPerspectiveDetail_returns_option_opinion_as_label() {
+        User user = user(1L);
+        BattleOption option = option(10L, battle(100L), BattleOptionLabel.A, "예술이 아니다");
+        Perspective perspective = Perspective.builder()
+                .battle(option.getBattle())
+                .user(user)
+                .option(option)
+                .content("관점 내용")
+                .build();
+        perspective.publish();
+        ReflectionTestUtils.setField(perspective, "id", 1000L);
+
+        when(perspectiveRepository.findById(1000L)).thenReturn(Optional.of(perspective));
+        when(userQueryService.findSummaryById(1L)).thenReturn(new UserSummary("user-1", "nick", "OWL"));
+        when(s3PresignedUrlService.generatePresignedUrl(anyString())).thenReturn("character-url");
+        when(perspectiveLikeRepository.existsByPerspectiveAndUserId(perspective, 1L)).thenReturn(false);
+
+        PerspectiveDetailResponse response = perspectiveService.getPerspectiveDetail(1000L, 1L);
+
+        assertThat(response.option().label()).isEqualTo("예술이 아니다");
+        assertThat(response.option().title()).isEqualTo("예술이 아니다");
+    }
+
+    private Battle battle(Long id) {
+        Battle battle = Battle.builder()
+                .title("battle")
+                .summary("summary")
+                .targetDate(LocalDate.now())
+                .status(BattleStatus.PUBLISHED)
+                .build();
+        ReflectionTestUtils.setField(battle, "id", id);
+        return battle;
+    }
+
+    private BattleOption option(Long id, Battle battle, BattleOptionLabel label, String title) {
+        BattleOption option = BattleOption.builder()
+                .battle(battle)
+                .label(label)
+                .title(title)
+                .stance("stance")
+                .build();
+        ReflectionTestUtils.setField(option, "id", id);
+        return option;
+    }
+
+    private User user(Long id) {
+        User user = User.builder()
+                .userTag("user-" + id)
+                .nickname("nick")
+                .role(UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- Ex) - #이슈번호 -->
<!-- 연관된 이슈 번호를 링크 형태로 작성하세요 -->
- #237

## 📝 작업 내용
<!-- 이번 PR/이슈에서 실제 수행한 작업 내용을 작성하세요 -->

### ♻️ Refactor
<!-- 기존 코드 리팩토링 내용 작성 -->
| 내용 | 파일 |
|------|------|
| 관점 목록 필터를 `optionId` 기반으로 변경 | `PerspectiveController.java`, `PerspectiveService.java` |
| 관점 목록/상세/댓글 응답의 `A/B` 표시값을 옵션 `title` 기반으로 정리 | `PerspectiveService.java`, `PerspectiveCommentService.java`, `BattleOptionDisplay.java` |
| 사용자 배틀 상세 옵션 `label`과 투표 통계 이미지 응답 구조 정리 | `BattleConverter.java`, `BattleOptionResponse.java`, `VoteStatsResponse.java`, `BattleVoteServiceImpl.java`, `OptionStatResponse.java` |

### 📚 Docs
<!-- 문서 수정 내용 작성 -->
| 내용 | 파일 |
|------|------|
| 관점 목록 필터 파라미터 및 옵션 표시 응답 예시 갱신 | `docs/api-specs/perspectives-api.md` |
| 투표 통계 이미지 `URL` 및 내 투표 `option label` 응답 설명 추가 | `docs/api-specs/vote-api.md` |

### 🧪 Test
<!-- 테스트 코드 추가/수정 내용 작성 -->
| 내용 | 파일 |
|------|------|
| 관점 상세/댓글 응답에서 옵션 `title` 표시 검증 테스트 추가 | `PerspectiveServiceTest.java`, `PerspectiveCommentServiceTest.java` |
| `OAuth` 테스트를 현재 `AuthService`/`LoginRequest` 생성자 시그니처에 맞게 보정 | `OAuthServiceTest.java` |

## 📌 공유 사항
<!-- 팀원에게 공유할 내용이나 참고 사항 작성 -->
<!-- 노션 환경 설정 파일 확인 부탁드립니다! -->
1. `GET /api/v1/battles/{battleId}/perspectives` 필터는 `optionId`를 사용합니다.
2. `VoteStatsResponse.options[]`는 철학자 이미지 리소스 리다이렉트 URL을 `imageUrl`로 반환합니다.
3. 검증 : `./gradlew.bat compileJava` 성공

## ✅ 체크리스트
<!-- PR 제출 전에 체크해야 할 사항들 -->
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
<!-- Swagger, Postman, JUnit 테스트 화면 첨부 -->
<!-- 기능 동작 화면이나 테스트 결과 캡처를 첨부하면 좋습니다 -->
- N/A (API 응답 구조 변경)

## 💬 리뷰 요구사항
<!-- 리뷰어에게 요청하는 구체적인 사항 작성 -->
<!-- 종료 의도 판단을 Java 키워드 → AI 2차 검증 구조로 설계했는데
해당 구조가 유지보수 및 확장 측면에서 적절한지 의견 부탁드립니다. -->
1. 관점 필터 파라미터를 `optionId`로 고정한 `API` 계약이 프론트 연동에 적절한지 확인 부탁드립니다.