### PR TITLE
#243 [Refactor] 배틀 옵션 label -> displayOrder로 변경

### DIFF
--- a/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleOptionRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/battle/request/AdminBattleOptionRequest.java
@@ -1,14 +1,12 @@
 package com.swyp.picke.domain.admin.dto.battle.request;
 
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
-
 import java.util.List;
 
 public record AdminBattleOptionRequest(
-        BattleOptionLabel label,
         String title,
         String stance,
         String representative,
         String imageUrl,
+        Integer displayOrder,
         List<Long> tagIds
 ) {}

--- a/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/com/swyp/picke/domain/battle/converter/BattleConverter.java
@@ -6,7 +6,6 @@ import com.swyp.picke.domain.battle.dto.response.*;
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
 import com.swyp.picke.domain.battle.enums.BattleCreatorType;
-import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.tag.entity.Tag;
 import com.swyp.picke.domain.tag.enums.TagType;
 import com.swyp.picke.domain.user.entity.User;
@@ -29,7 +28,6 @@ public class BattleConverter {
     private static final String BASE_SHARE_URL = "https://pique.app/battles/";
     private static final Comparator<BattleOption> OPTION_SORTER =
             Comparator.comparing((BattleOption option) -> option.getDisplayOrder() == null ? Integer.MAX_VALUE : option.getDisplayOrder())
-                    .thenComparing(option -> option.getLabel() == null ? "" : option.getLabel().name())
                     .thenComparing(BattleOption::getId);
 
     public Battle toEntity(AdminBattleCreateRequest request, User admin) {
@@ -85,7 +83,7 @@ public class BattleConverter {
                 battle.getStatus(),
                 battle.getCreatorType(),
                 toTagResponses(tags, null),
-                toOptionResponses(options, optionTagsMap, false),
+                toOptionResponses(options, optionTagsMap),
                 battle.getCreatedAt(),
                 battle.getUpdatedAt()
         );
@@ -104,7 +102,7 @@ public class BattleConverter {
                 participantsCount == null ? 0L : participantsCount,
                 battle.getAudioDuration() == null ? 0 : battle.getAudioDuration(),
                 toTagResponses(tags, null),
-                toOptionResponses(options, optionTagsMap, true)
+                toOptionResponses(options, optionTagsMap)
         );
 
         return new BattleUserDetailResponse(
@@ -122,7 +120,6 @@ public class BattleConverter {
     public BattleScenarioResponse toScenarioResponse(Battle battle, List<BattleOption> options) {
         List<BattleScenarioResponse.PhilosopherProfileResponse> profiles = options.stream()
                 .map(opt -> new BattleScenarioResponse.PhilosopherProfileResponse(
-                        opt.getLabel().name(),
                         opt.getRepresentative(),
                         opt.getStance(),
                         urlProvider.getImageUrl(FileCategory.PHILOSOPHER, opt.getImageUrl())
@@ -133,8 +130,7 @@ public class BattleConverter {
 
     private List<BattleOptionResponse> toOptionResponses(
             List<BattleOption> options,
-            Map<Long, List<Tag>> optionTagsMap,
-            boolean useDisplayLabel
+            Map<Long, List<Tag>> optionTagsMap
     ) {
         if (options == null) return List.of();
         return options.stream()
@@ -143,9 +139,6 @@ public class BattleConverter {
                     List<Tag> optionTags = optionTagsMap.getOrDefault(option.getId(), List.of());
                     return new BattleOptionResponse(
                             option.getId(),
-                            useDisplayLabel
-                                    ? BattleOptionDisplay.opinion(option)
-                                    : (option.getLabel() == null ? null : option.getLabel().name()),
                             option.getTitle(),
                             option.getStance(),
                             option.getRepresentative(),
@@ -161,7 +154,6 @@ public class BattleConverter {
                 .sorted(OPTION_SORTER)
                 .map(option -> new TodayOptionResponse(
                         option.getId(),
-                        option.getLabel(),
                         option.getTitle(),
                         option.getRepresentative(),
                         option.getStance(),

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleOptionResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleOptionResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 public record BattleOptionResponse(
         Long optionId,
-        String label,
         String title,
         String stance,
         String representative,

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleScenarioResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/BattleScenarioResponse.java
@@ -5,9 +5,8 @@ import java.util.List;
 public record BattleScenarioResponse(
         String title,
         List<PhilosopherProfileResponse> philosophers
-) {
+    ) {
     public record PhilosopherProfileResponse(
-            String label,
             String name,
             String stance,
             String imageUrl

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/OptionStatResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/OptionStatResponse.java
@@ -1,16 +1,8 @@
 package com.swyp.picke.domain.battle.dto.response;
 
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
-
-/**
- * 유저 - 옵션별 실시간 통계
- * 역할: 각 선택지별로 몇 명이 선택했는지, 퍼센트(%)는 얼마인지 담습니다.
- */
-
 public record OptionStatResponse(
-        Long optionId,          // 옵션 고유 ID
-        BattleOptionLabel label,// 라벨 (A, B)
-        String title,           // 옵션 명칭
-        Long voteCount,         // 해당 옵션의 득표 수
-        Double ratio            // 해당 옵션의 득표 비율 (0~100.0)
+        Long optionId,
+        String title,
+        Long voteCount,
+        Double ratio
 ) {}

--- a/src/main/java/com/swyp/picke/domain/battle/dto/response/TodayOptionResponse.java
+++ b/src/main/java/com/swyp/picke/domain/battle/dto/response/TodayOptionResponse.java
@@ -1,10 +1,7 @@
 package com.swyp.picke.domain.battle.dto.response;
 
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
-
 public record TodayOptionResponse(
         Long optionId,
-        BattleOptionLabel label,
         String title,
         String representative,
         String stance,

--- a/src/main/java/com/swyp/picke/domain/battle/entity/BattleOption.java
+++ b/src/main/java/com/swyp/picke/domain/battle/entity/BattleOption.java
@@ -1,12 +1,9 @@
 package com.swyp.picke.domain.battle.entity;
 
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.global.common.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -28,10 +25,6 @@ public class BattleOption extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "battle_id", nullable = false)
     private Battle battle;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
-    private BattleOptionLabel label;
 
     @Column(nullable = false, length = 100)
     private String title;
@@ -57,7 +50,6 @@ public class BattleOption extends BaseEntity {
     @Builder
     public BattleOption(
             Battle battle,
-            BattleOptionLabel label,
             String title,
             String stance,
             String representative,
@@ -65,7 +57,6 @@ public class BattleOption extends BaseEntity {
             Integer displayOrder
     ) {
         this.battle = battle;
-        this.label = label;
         this.title = title;
         this.stance = stance;
         this.representative = representative;
@@ -84,7 +75,7 @@ public class BattleOption extends BaseEntity {
         }
     }
 
-    public void update(String title, String stance, String representative, String imageUrl) {
+    public void update(String title, String stance, String representative, String imageUrl, Integer displayOrder) {
         if (title != null) {
             this.title = title;
         }

--- a/src/main/java/com/swyp/picke/domain/battle/repository/BattleOptionRepository.java
+++ b/src/main/java/com/swyp/picke/domain/battle/repository/BattleOptionRepository.java
@@ -2,25 +2,20 @@ package com.swyp.picke.domain.battle.repository;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
-
 public interface BattleOptionRepository extends JpaRepository<BattleOption, Long> {
 
     @Query("SELECT bo FROM BattleOption bo " +
             "WHERE bo.battle = :battle " +
-            "ORDER BY COALESCE(bo.displayOrder, 9999), bo.label, bo.id")
+            "ORDER BY COALESCE(bo.displayOrder, 9999), bo.id")
     List<BattleOption> findByBattle(@Param("battle") Battle battle);
-
-    Optional<BattleOption> findByBattleAndLabel(Battle battle, BattleOptionLabel label);
 
     @Query("SELECT bo FROM BattleOption bo " +
             "WHERE bo.battle IN :battles " +
-            "ORDER BY bo.battle.id, COALESCE(bo.displayOrder, 9999), bo.label, bo.id")
+            "ORDER BY bo.battle.id, COALESCE(bo.displayOrder, 9999), bo.id")
     List<BattleOption> findByBattleIn(@Param("battles") List<Battle> battles);
 }

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleService.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleService.java
@@ -12,7 +12,6 @@ import com.swyp.picke.domain.battle.dto.response.TodayBattleListResponse;
 import com.swyp.picke.domain.battle.dto.response.TodayBattleResponse;
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.user.dto.response.UserBattleStatusResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,8 +21,6 @@ public interface BattleService {
     Battle findById(Long battleId);
 
     BattleOption findOptionById(Long optionId);
-
-    BattleOption findOptionByBattleIdAndLabel(Long battleId, BattleOptionLabel label);
 
     List<TodayBattleResponse> getEditorPicks();
 

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -11,8 +11,8 @@ import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
 import com.swyp.picke.domain.battle.entity.BattleOptionTag;
 import com.swyp.picke.domain.battle.entity.BattleTag;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.battle.enums.BattleStatus;
+import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.user.dto.response.UserBattleStatusResponse;
 import com.swyp.picke.domain.user.enums.UserBattleStep;
 import com.swyp.picke.domain.battle.repository.BattleOptionRepository;
@@ -244,7 +244,7 @@ public class BattleServiceImpl implements BattleService {
         VoteSide voteStatus = optionalVote
                 .map(BattleVote -> {
                     if (BattleVote.getPostVoteOption() != null) {
-                        return BattleVote.getPostVoteOption().getLabel() == BattleOptionLabel.A ? VoteSide.PRO : VoteSide.CON;
+                        return BattleOptionDisplay.voteSide(BattleVote.getPostVoteOption());
                     }
                     return null;
                 })
@@ -303,7 +303,7 @@ public class BattleServiceImpl implements BattleService {
             Long voteCount = option.getVoteCount() == null ? 0L : option.getVoteCount();
             Long totalCount = battle.getTotalParticipantsCount() == null ? 0L : battle.getTotalParticipantsCount();
             Double ratio = (totalCount == 0L) ? 0.0 : Math.round((double) voteCount / totalCount * 1000) / 10.0;
-            return new OptionStatResponse(option.getId(), option.getLabel(), option.getTitle(), voteCount, ratio);
+            return new OptionStatResponse(option.getId(), option.getTitle(), voteCount, ratio);
         }).toList();
     }
 
@@ -336,7 +336,8 @@ public class BattleServiceImpl implements BattleService {
 
         List<BattleOption> savedOptions = new ArrayList<>();
         if (request.options() != null) {
-            for (AdminBattleOptionRequest optionRequest : request.options()) {
+            for (int optionIndex = 0; optionIndex < request.options().size(); optionIndex++) {
+                AdminBattleOptionRequest optionRequest = request.options().get(optionIndex);
                 String resolvedImageKey = resolveStoredImageKey(
                         optionRequest.imageUrl(),
                         request.status(),
@@ -344,11 +345,11 @@ public class BattleServiceImpl implements BattleService {
                 );
                 BattleOption option = BattleOption.builder()
                         .battle(battle)
-                        .label(optionRequest.label())
                         .title(optionRequest.title())
                         .stance(optionRequest.stance())
                         .representative(optionRequest.representative())
                         .imageUrl(resolvedImageKey)
+                        .displayOrder(resolveDisplayOrder(optionRequest, optionIndex))
                         .build();
                 option = battleOptionRepository.save(option);
 
@@ -419,15 +420,10 @@ public class BattleServiceImpl implements BattleService {
 
         if (request.options() != null) {
             List<BattleOption> existingOptions = battleOptionRepository.findByBattle(battle);
-            Map<BattleOptionLabel, BattleOption> existingOptionMap = existingOptions.stream()
-                    .collect(Collectors.toMap(BattleOption::getLabel, option -> option));
-
-            Set<BattleOptionLabel> requestedLabels = new HashSet<>();
-
-            for (AdminBattleOptionRequest optionRequest : request.options()) {
-                requestedLabels.add(optionRequest.label());
-
-                BattleOption option = existingOptionMap.get(optionRequest.label());
+            for (int optionIndex = 0; optionIndex < request.options().size(); optionIndex++) {
+                AdminBattleOptionRequest optionRequest = request.options().get(optionIndex);
+                BattleOption option = optionIndex < existingOptions.size() ? existingOptions.get(optionIndex) : null;
+                int displayOrder = resolveDisplayOrder(optionRequest, optionIndex);
                 String resolvedOptionImageKey = resolveStoredImageKey(
                         optionRequest.imageUrl(),
                         request.status(),
@@ -436,11 +432,11 @@ public class BattleServiceImpl implements BattleService {
                 if (option == null) {
                     option = BattleOption.builder()
                             .battle(battle)
-                            .label(optionRequest.label())
                             .title(optionRequest.title())
                             .stance(optionRequest.stance())
                             .representative(optionRequest.representative())
                             .imageUrl(resolvedOptionImageKey)
+                            .displayOrder(displayOrder)
                             .build();
                     option = battleOptionRepository.save(option);
                 } else {
@@ -449,14 +445,14 @@ public class BattleServiceImpl implements BattleService {
                         deleteStoredAsset(existingOptionImageKey);
                     }
                     option.update(optionRequest.title(), optionRequest.stance(),
-                            optionRequest.representative(), resolvedOptionImageKey);
+                            optionRequest.representative(), resolvedOptionImageKey, displayOrder);
                 }
 
                 replaceBattleOptionTags(option, optionRequest.tagIds());
             }
 
             List<BattleOption> removedOptions = existingOptions.stream()
-                    .filter(existing -> !requestedLabels.contains(existing.getLabel()))
+                    .skip(request.options().size())
                     .toList();
 
             for (BattleOption removedOption : removedOptions) {
@@ -567,7 +563,7 @@ public class BattleServiceImpl implements BattleService {
                     BattleStatus.PUBLISHED,
                     FileCategory.PHILOSOPHER
             );
-            option.update(null, null, null, resolvedImageKey);
+            option.update(null, null, null, resolvedImageKey, null);
         }
     }
 
@@ -651,13 +647,6 @@ public class BattleServiceImpl implements BattleService {
     @Override
     public BattleOption findOptionById(Long optionId) {
         return battleOptionRepository.findById(optionId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BATTLE_OPTION_NOT_FOUND));
-    }
-
-    @Override
-    public BattleOption findOptionByBattleIdAndLabel(Long battleId, BattleOptionLabel label) {
-        Battle battle = findById(battleId);
-        return battleOptionRepository.findByBattleAndLabel(battle, label)
                 .orElseThrow(() -> new CustomException(ErrorCode.BATTLE_OPTION_NOT_FOUND));
     }
 
@@ -747,6 +736,10 @@ public class BattleServiceImpl implements BattleService {
         if (count < 2 || count > 4) {
             throw new CustomException(ErrorCode.BATTLE_INVALID_OPTION_COUNT);
         }
+    }
+
+    private int resolveDisplayOrder(AdminBattleOptionRequest optionRequest, int optionIndex) {
+        return optionRequest.displayOrder() == null ? optionIndex + 1 : optionRequest.displayOrder();
     }
 }
 

--- a/src/main/java/com/swyp/picke/domain/battle/util/BattleOptionDisplay.java
+++ b/src/main/java/com/swyp/picke/domain/battle/util/BattleOptionDisplay.java
@@ -1,6 +1,7 @@
 package com.swyp.picke.domain.battle.util;
 
 import com.swyp.picke.domain.battle.entity.BattleOption;
+import com.swyp.picke.domain.user.enums.VoteSide;
 
 public final class BattleOptionDisplay {
 
@@ -15,6 +16,13 @@ public final class BattleOptionDisplay {
         if (title != null && !title.isBlank()) {
             return title;
         }
-        return option.getLabel() == null ? null : option.getLabel().name();
+        return null;
+    }
+
+    public static VoteSide voteSide(BattleOption option) {
+        if (option == null || option.getDisplayOrder() == null) {
+            return null;
+        }
+        return option.getDisplayOrder() == 1 ? VoteSide.PRO : VoteSide.CON;
     }
 }

--- a/src/main/java/com/swyp/picke/domain/home/service/HomeService.java
+++ b/src/main/java/com/swyp/picke/domain/home/service/HomeService.java
@@ -75,8 +75,8 @@ public class HomeService {
         return new HomeEditorPickResponse(
                 battle.battleId(),
                 battle.thumbnailUrl(),
-                findOptionTitle(battle.options(), BattleOptionLabel.A),
-                findOptionTitle(battle.options(), BattleOptionLabel.B),
+                findOptionTitle(battle.options(), 0),
+                findOptionTitle(battle.options(), 1),
                 battle.title(),
                 battle.summary(),
                 battle.tags(),
@@ -98,8 +98,8 @@ public class HomeService {
     private HomeBestBattleResponse toBestBattle(TodayBattleResponse battle) {
         return new HomeBestBattleResponse(
                 battle.battleId(),
-                findOptionRepresentative(battle.options(), BattleOptionLabel.A),
-                findOptionRepresentative(battle.options(), BattleOptionLabel.B),
+                findOptionRepresentative(battle.options(), 0),
+                findOptionRepresentative(battle.options(), 1),
                 battle.title(),
                 battle.tags(),
                 battle.audioDuration(),
@@ -159,43 +159,45 @@ public class HomeService {
                 battle.thumbnailUrl(),
                 battle.title(),
                 battle.summary(),
-                findOptionRepresentative(battle.options(), BattleOptionLabel.A),
-                findOptionTitle(battle.options(), BattleOptionLabel.A),
-                findRepresentativeImageUrl(battle.options(), BattleOptionLabel.A),
-                findOptionRepresentative(battle.options(), BattleOptionLabel.B),
-                findOptionTitle(battle.options(), BattleOptionLabel.B),
-                findRepresentativeImageUrl(battle.options(), BattleOptionLabel.B),
+                findOptionRepresentative(battle.options(), 0),
+                findOptionTitle(battle.options(), 0),
+                findRepresentativeImageUrl(battle.options(), 0),
+                findOptionRepresentative(battle.options(), 1),
+                findOptionTitle(battle.options(), 1),
+                findRepresentativeImageUrl(battle.options(), 1),
                 battle.tags(),
                 battle.audioDuration(),
                 battle.viewCount()
         );
     }
 
-    private String findOptionTitle(List<TodayOptionResponse> options, BattleOptionLabel label) {
-        return Optional.ofNullable(options).orElse(List.of()).stream()
-                .filter(option -> option.label() == label)
+    private String findOptionTitle(List<TodayOptionResponse> options, int optionIndex) {
+        return findBattleOption(options, optionIndex)
                 .map(TodayOptionResponse::title)
                 .filter(Objects::nonNull)
-                .findFirst()
                 .orElse(null);
     }
 
-    private String findOptionRepresentative(List<TodayOptionResponse> options, BattleOptionLabel label) {
-        return Optional.ofNullable(options).orElse(List.of()).stream()
-                .filter(option -> option.label() == label)
+    private String findOptionRepresentative(List<TodayOptionResponse> options, int optionIndex) {
+        return findBattleOption(options, optionIndex)
                 .map(TodayOptionResponse::representative)
                 .filter(Objects::nonNull)
-                .findFirst()
                 .orElse(null);
     }
 
-    private String findRepresentativeImageUrl(List<TodayOptionResponse> options, BattleOptionLabel label) {
-        return Optional.ofNullable(options).orElse(List.of()).stream()
-                .filter(option -> option.label() == label)
+    private String findRepresentativeImageUrl(List<TodayOptionResponse> options, int optionIndex) {
+        return findBattleOption(options, optionIndex)
                 .map(TodayOptionResponse::imageUrl)
                 .filter(Objects::nonNull)
-                .findFirst()
                 .orElse(null);
+    }
+
+    private Optional<TodayOptionResponse> findBattleOption(List<TodayOptionResponse> options, int optionIndex) {
+        List<TodayOptionResponse> safeOptions = Optional.ofNullable(options).orElse(List.of());
+        if (optionIndex < 0 || optionIndex >= safeOptions.size()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(safeOptions.get(optionIndex));
     }
 
     private QuizOption findQuizOption(List<QuizOption> options, QuizOptionLabel label) {

--- a/src/main/java/com/swyp/picke/domain/recommendation/dto/response/RecommendationListResponse.java
+++ b/src/main/java/com/swyp/picke/domain/recommendation/dto/response/RecommendationListResponse.java
@@ -23,7 +23,6 @@ public record RecommendationListResponse(List<Item> items, String nextCursor, bo
     @Schema(name = "RecommendationOptionSummary")
     public record OptionSummary(
             Long optionId,
-            String label,
             String title,
             String stance,
             String representative,

--- a/src/main/java/com/swyp/picke/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/swyp/picke/domain/recommendation/service/RecommendationService.java
@@ -92,7 +92,6 @@ public class RecommendationService {
         List<RecommendationListResponse.OptionSummary> optionSummaries = options.stream()
                 .map(opt -> new RecommendationListResponse.OptionSummary(
                         opt.getId(),
-                        opt.getLabel().name(),
                         opt.getTitle(),
                         opt.getStance(),
                         opt.getRepresentative(),

--- a/src/main/java/com/swyp/picke/domain/scenario/service/ScenarioServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/scenario/service/ScenarioServiceImpl.java
@@ -68,9 +68,10 @@ public class ScenarioServiceImpl implements ScenarioService {
         if (optionalVote.isPresent()) {
             BattleVote vote = optionalVote.get();
             if (scenario.getIsInteractive()) {
-                if (vote.getPreVoteOption().getLabel().name().equalsIgnoreCase("A")) {
+                Integer displayOrder = vote.getPreVoteOption().getDisplayOrder();
+                if (displayOrder != null && displayOrder == 1) {
                     recommendedKey = AudioPathType.PATH_A;
-                } else if (vote.getPreVoteOption().getLabel().name().equalsIgnoreCase("B")) {
+                } else if (displayOrder != null && displayOrder == 2) {
                     recommendedKey = AudioPathType.PATH_B;
                 }
             }
@@ -334,12 +335,25 @@ public class ScenarioServiceImpl implements ScenarioService {
 
         if (options != null) {
             for (BattleOption option : options) {
-                String key = String.valueOf(option.getLabel());
-                map.put(key, option.getRepresentative());
+                String key = toSpeakerKey(option);
+                if (key != null) {
+                    map.put(key, option.getRepresentative());
+                }
             }
         }
 
         return map;
+    }
+
+    private String toSpeakerKey(BattleOption option) {
+        if (option == null || option.getDisplayOrder() == null) {
+            return null;
+        }
+        return switch (option.getDisplayOrder()) {
+            case 1 -> "A";
+            case 2 -> "B";
+            default -> null;
+        };
     }
 
     private Set<SpeakerType> updateVoiceSettings(Scenario scenario, Map<SpeakerType, String> requestedVoiceSettings) {

--- a/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
@@ -2,8 +2,8 @@ package com.swyp.picke.domain.user.service;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.battle.service.BattleQueryService;
+import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
 import com.swyp.picke.domain.perspective.entity.Perspective;
 import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
 import com.swyp.picke.domain.perspective.entity.PerspectiveLike;
@@ -147,10 +147,8 @@ public class MypageService {
         int pageOffset = offset == null || offset < 0 ? 0 : offset;
         int pageSize = size == null || size <= 0 ? DEFAULT_PAGE_SIZE : size;
 
-        BattleOptionLabel label = voteSide != null ? toOptionLabel(voteSide) : null;
-
-        List<BattleVote> votes = voteQueryService.findUserVotes(user.getId(), pageOffset, pageSize, label);
-        long totalCount = voteQueryService.countUserVotes(user.getId(), label);
+        List<BattleVote> votes = voteQueryService.findUserVotes(user.getId(), pageOffset, pageSize, voteSide);
+        long totalCount = voteQueryService.countUserVotes(user.getId(), voteSide);
 
         List<Long> battleIds = votes.stream().map(v -> v.getBattle().getId()).toList();
         Map<Long, String> categoryMap = battleQueryService.getCategoryNamesByBattleIds(battleIds); // 배틀별 카테고리명 조회
@@ -160,8 +158,7 @@ public class MypageService {
                     Battle battle = BattleVote.getBattle();
                     BattleOption selectedOption = BattleVote.getPostVoteOption() != null
                             ? BattleVote.getPostVoteOption() : BattleVote.getPreVoteOption();
-                    VoteSide side = selectedOption.getLabel() == BattleOptionLabel.A
-                            ? VoteSide.PRO : VoteSide.CON;
+                    VoteSide side = BattleOptionDisplay.voteSide(selectedOption);
                     String category = categoryMap.get(battle.getId());
 
                     return new BattleRecordListResponse.BattleRecordItem(
@@ -254,9 +251,7 @@ public class MypageService {
                 characterImageUrl
         );
 
-        VoteSide voteSide = option != null
-                ? (option.getLabel() == BattleOptionLabel.A ? VoteSide.PRO : VoteSide.CON)
-                : null;
+        VoteSide voteSide = BattleOptionDisplay.voteSide(option);
 
         return new ContentActivityListResponse.ContentActivityItem(
                 activityId, activityType,
@@ -359,14 +354,6 @@ public class MypageService {
                         PhilosopherType.resolveImageKey(type.getLabel())
                 )
         );
-    }
-
-    private VoteSide toVoteSide(BattleOptionLabel label) {
-        return label == BattleOptionLabel.A ? VoteSide.PRO : VoteSide.CON;
-    }
-
-    private BattleOptionLabel toOptionLabel(VoteSide voteSide) {
-        return voteSide == VoteSide.PRO ? BattleOptionLabel.A : BattleOptionLabel.B;
     }
 
     private NotificationSettingsResponse toNotificationSettingsResponse(UserSettings settings) {

--- a/src/main/java/com/swyp/picke/domain/vote/repository/BattleVoteRepository.java
+++ b/src/main/java/com/swyp/picke/domain/vote/repository/BattleVoteRepository.java
@@ -2,7 +2,6 @@ package com.swyp.picke.domain.vote.repository;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.user.entity.User;
 import com.swyp.picke.domain.vote.entity.BattleVote;
 import org.springframework.data.domain.Pageable;
@@ -35,14 +34,22 @@ public interface BattleVoteRepository extends JpaRepository<BattleVote, Long> {
     List<BattleVote> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
 
     @Query("SELECT v FROM BattleVote v JOIN FETCH v.battle JOIN FETCH v.preVoteOption " +
-           "WHERE v.user.id = :userId AND v.preVoteOption.label = :label ORDER BY v.createdAt DESC")
-    List<BattleVote> findByUserIdAndPreVoteOptionLabelOrderByCreatedAtDesc(
-            @Param("userId") Long userId, @Param("label") BattleOptionLabel label, Pageable pageable);
+           "WHERE v.user.id = :userId AND v.preVoteOption.displayOrder = :displayOrder ORDER BY v.createdAt DESC")
+    List<BattleVote> findByUserIdAndPreVoteOptionDisplayOrderOrderByCreatedAtDesc(
+            @Param("userId") Long userId, @Param("displayOrder") Integer displayOrder, Pageable pageable);
+
+    @Query("SELECT v FROM BattleVote v JOIN FETCH v.battle JOIN FETCH v.preVoteOption " +
+           "WHERE v.user.id = :userId AND v.preVoteOption.displayOrder <> :displayOrder ORDER BY v.createdAt DESC")
+    List<BattleVote> findByUserIdAndPreVoteOptionDisplayOrderNotOrderByCreatedAtDesc(
+            @Param("userId") Long userId, @Param("displayOrder") Integer displayOrder, Pageable pageable);
 
     long countByUserId(Long userId);
 
-    @Query("SELECT COUNT(v) FROM BattleVote v WHERE v.user.id = :userId AND v.preVoteOption.label = :label")
-    long countByUserIdAndPreVoteOptionLabel(@Param("userId") Long userId, @Param("label") BattleOptionLabel label);
+    @Query("SELECT COUNT(v) FROM BattleVote v WHERE v.user.id = :userId AND v.preVoteOption.displayOrder = :displayOrder")
+    long countByUserIdAndPreVoteOptionDisplayOrder(@Param("userId") Long userId, @Param("displayOrder") Integer displayOrder);
+
+    @Query("SELECT COUNT(v) FROM BattleVote v WHERE v.user.id = :userId AND v.preVoteOption.displayOrder <> :displayOrder")
+    long countByUserIdAndPreVoteOptionDisplayOrderNot(@Param("userId") Long userId, @Param("displayOrder") Integer displayOrder);
 
     @Query("SELECT COUNT(v) FROM BattleVote v WHERE v.user.id = :userId " +
             "AND v.postVoteOption IS NOT NULL " +

--- a/src/main/java/com/swyp/picke/domain/vote/service/VoteQueryService.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/VoteQueryService.java
@@ -1,7 +1,7 @@
 package com.swyp.picke.domain.vote.service;
 
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
+import com.swyp.picke.domain.user.enums.VoteSide;
 import com.swyp.picke.domain.vote.entity.BattleVote;
 import com.swyp.picke.domain.vote.repository.BattleVoteRepository;
 import java.util.List;
@@ -18,17 +18,25 @@ public class VoteQueryService {
 
     private final BattleVoteRepository battleVoteRepository;
 
-    public List<BattleVote> findUserVotes(Long userId, int offset, int size, BattleOptionLabel label) {
+    public List<BattleVote> findUserVotes(Long userId, int offset, int size, VoteSide voteSide) {
         PageRequest pageable = PageRequest.of(offset / size, size);
-        return label != null
-                ? battleVoteRepository.findByUserIdAndPreVoteOptionLabelOrderByCreatedAtDesc(userId, label, pageable)
-                : battleVoteRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        if (voteSide == VoteSide.PRO) {
+            return battleVoteRepository.findByUserIdAndPreVoteOptionDisplayOrderOrderByCreatedAtDesc(userId, 1, pageable);
+        }
+        if (voteSide == VoteSide.CON) {
+            return battleVoteRepository.findByUserIdAndPreVoteOptionDisplayOrderNotOrderByCreatedAtDesc(userId, 1, pageable);
+        }
+        return battleVoteRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
     }
 
-    public long countUserVotes(Long userId, BattleOptionLabel label) {
-        return label != null
-                ? battleVoteRepository.countByUserIdAndPreVoteOptionLabel(userId, label)
-                : battleVoteRepository.countByUserId(userId);
+    public long countUserVotes(Long userId, VoteSide voteSide) {
+        if (voteSide == VoteSide.PRO) {
+            return battleVoteRepository.countByUserIdAndPreVoteOptionDisplayOrder(userId, 1);
+        }
+        if (voteSide == VoteSide.CON) {
+            return battleVoteRepository.countByUserIdAndPreVoteOptionDisplayOrderNot(userId, 1);
+        }
+        return battleVoteRepository.countByUserId(userId);
     }
 
     public long countTotalParticipation(Long userId) {

--- a/src/main/resources/db/migration/V20260521_01__drop_battle_option_label.sql
+++ b/src/main/resources/db/migration/V20260521_01__drop_battle_option_label.sql
@@ -1,0 +1,45 @@
+DO $$
+BEGIN
+    IF to_regclass('public.battle_options') IS NULL THEN
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'battle_options'
+          AND column_name = 'label'
+    ) THEN
+        UPDATE battle_options
+        SET display_order = CASE label
+            WHEN 'A' THEN 1
+            WHEN 'B' THEN 2
+            WHEN 'C' THEN 3
+            WHEN 'D' THEN 4
+            ELSE display_order
+        END
+        WHERE display_order IS NULL;
+    END IF;
+
+    WITH ranked_options AS (
+        SELECT
+            id,
+            ROW_NUMBER() OVER (
+                PARTITION BY battle_id
+                ORDER BY COALESCE(display_order, 9999), id
+            ) AS fallback_order
+        FROM battle_options
+    )
+    UPDATE battle_options bo
+    SET display_order = ranked_options.fallback_order
+    FROM ranked_options
+    WHERE bo.id = ranked_options.id
+      AND bo.display_order IS NULL;
+
+    ALTER TABLE battle_options ALTER COLUMN display_order SET NOT NULL;
+    ALTER TABLE battle_options DROP COLUMN IF EXISTS label;
+
+    CREATE INDEX IF NOT EXISTS idx_battle_options_battle_order
+        ON battle_options (battle_id, display_order, id);
+END $$;

--- a/src/main/resources/db/migration/V20260521_rollback__restore_battle_option_label.sql
+++ b/src/main/resources/db/migration/V20260521_rollback__restore_battle_option_label.sql
@@ -1,0 +1,42 @@
+-- Rollback for V20260521_01__drop_battle_option_label.sql.
+-- Restore battle option labels from the option order before rolling back application code.
+
+ALTER TABLE battle_options
+    ADD COLUMN IF NOT EXISTS label VARCHAR(10);
+
+WITH ordered_options AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY battle_id
+            ORDER BY display_order, id
+        ) AS option_order
+    FROM battle_options
+)
+UPDATE battle_options bo
+SET label = CASE oo.option_order
+    WHEN 1 THEN 'A'
+    WHEN 2 THEN 'B'
+    WHEN 3 THEN 'C'
+    WHEN 4 THEN 'D'
+    ELSE NULL
+END
+FROM ordered_options oo
+WHERE bo.id = oo.id
+  AND bo.label IS NULL;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM battle_options
+        WHERE label IS NULL
+    ) THEN
+        RAISE EXCEPTION 'battle_options.label rollback failed: unsupported option count';
+    END IF;
+END $$;
+
+ALTER TABLE battle_options
+    ALTER COLUMN label SET NOT NULL;
+
+DROP INDEX IF EXISTS idx_battle_options_battle_order;

--- a/src/main/resources/static/js/admin/api/api-save.js
+++ b/src/main/resources/static/js/admin/api/api-save.js
@@ -131,7 +131,6 @@
                 tagIds: PickeData.selections.CATEGORY || [],
                 options: [
                     {
-                        label: 'A',
                         title: document.getElementById('char-a-title')?.value || '',
                         stance: document.getElementById('char-a-stance')?.value || '',
                         representative: document.getElementById('char-a-rep')?.value || '',
@@ -143,7 +142,6 @@
                         ]
                     },
                     {
-                        label: 'B',
                         title: document.getElementById('char-b-title')?.value || '',
                         stance: document.getElementById('char-b-stance')?.value || '',
                         representative: document.getElementById('char-b-rep')?.value || '',

--- a/src/main/resources/templates/admin/components/form-battle.html
+++ b/src/main/resources/templates/admin/components/form-battle.html
@@ -65,7 +65,6 @@
 
             <div class="bg-[#F8F9FA] p-6 rounded-2xl border border-gray-100 space-y-4">
                 <h3 class="text-blue-600 font-bold text-sm border-b border-blue-100 pb-2">선택지 A</h3>
-                <input type="hidden" name="options[0].label" value="A" />
                 <textarea id="char-a-title" name="options[0].title" rows="1" placeholder="A 주장" class="w-full bg-white border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-blue-400 form-scrollbar"></textarea>
                 <textarea id="char-a-rep" name="options[0].representative" rows="1" placeholder="A 철학자" class="w-full bg-white border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-blue-400 form-scrollbar"></textarea>
                 <textarea id="char-a-stance" name="options[0].stance" rows="2" placeholder="A 입장" class="w-full bg-white border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-blue-400 form-scrollbar"></textarea>
@@ -88,7 +87,6 @@
 
             <div class="bg-[#FFF8F8] p-6 rounded-2xl border border-gray-100 space-y-4">
                 <h3 class="text-red-600 font-bold text-sm border-b border-red-100 pb-2">선택지 B</h3>
-                <input type="hidden" name="options[1].label" value="B" />
                 <textarea id="char-b-title" name="options[1].title" rows="1" placeholder="B 주장" class="w-full bg-white border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-red-400 form-scrollbar"></textarea>
                 <textarea id="char-b-rep" name="options[1].representative" rows="1" placeholder="B 철학자" class="w-full bg-white border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-red-400 form-scrollbar"></textarea>
                 <textarea id="char-b-stance" name="options[1].stance" rows="2" placeholder="B 입장" class="w-full bg-white border border-gray-200 rounded-lg p-3 text-sm outline-none focus:border-red-400 form-scrollbar"></textarea>

--- a/src/test/java/com/swyp/picke/domain/admin/controller/AdminContentCreationIntegrationTest.java
+++ b/src/test/java/com/swyp/picke/domain/admin/controller/AdminContentCreationIntegrationTest.java
@@ -156,15 +156,15 @@ class AdminContentCreationIntegrationTest {
         assertThat(savedBattle.getTargetDate()).isEqualTo(targetDate);
 
         assertThat(options).hasSize(2);
-        BattleOption optionA = options.stream().filter(option -> option.getLabel().name().equals("A")).findFirst().orElseThrow();
-        BattleOption optionB = options.stream().filter(option -> option.getLabel().name().equals("B")).findFirst().orElseThrow();
+        BattleOption optionA = options.stream().filter(option -> option.getDisplayOrder() == 1).findFirst().orElseThrow();
+        BattleOption optionB = options.stream().filter(option -> option.getDisplayOrder() == 2).findFirst().orElseThrow();
 
         assertThat(optionA.getTitle()).isEqualTo("A 선택지");
         assertThat(optionA.getRepresentative()).isEqualTo("소크라테스");
-        assertThat(optionA.getDisplayOrder()).isNull();
+        assertThat(optionA.getDisplayOrder()).isEqualTo(1);
         assertThat(optionB.getTitle()).isEqualTo("B 선택지");
         assertThat(optionB.getRepresentative()).isEqualTo("플라톤");
-        assertThat(optionB.getDisplayOrder()).isNull();
+        assertThat(optionB.getDisplayOrder()).isEqualTo(2);
 
         assertThat(battleTagRepository.findByBattle(savedBattle)).hasSize(1);
         assertThat(battleOptionTagRepository.findByBattleOption(optionA)).hasSize(2);

--- a/src/test/java/com/swyp/picke/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/home/service/HomeServiceTest.java
@@ -193,8 +193,8 @@ class HomeServiceTest {
                 90,
                 List.of(),
                 List.of(
-                        new TodayOptionResponse(1001L, BattleOptionLabel.A, "A", "rep-a", "stance-a", "image-a"),
-                        new TodayOptionResponse(1002L, BattleOptionLabel.B, "B", "rep-b", "stance-b", "image-b")
+                        new TodayOptionResponse(1001L, "A", "rep-a", "stance-a", "image-a"),
+                        new TodayOptionResponse(1002L, "B", "rep-b", "stance-b", "image-b")
                 )
         );
     }

--- a/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentServiceTest.java
@@ -117,9 +117,9 @@ class PerspectiveCommentServiceTest {
     private BattleOption option(Long id, Battle battle, BattleOptionLabel label, String title) {
         BattleOption option = BattleOption.builder()
                 .battle(battle)
-                .label(label)
                 .title(title)
                 .stance("stance")
+                .displayOrder(label == BattleOptionLabel.A ? 1 : 2)
                 .build();
         ReflectionTestUtils.setField(option, "id", id);
         return option;

--- a/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/perspective/service/PerspectiveServiceTest.java
@@ -104,9 +104,9 @@ class PerspectiveServiceTest {
     private BattleOption option(Long id, Battle battle, BattleOptionLabel label, String title) {
         BattleOption option = BattleOption.builder()
                 .battle(battle)
-                .label(label)
                 .title(title)
                 .stance("stance")
+                .displayOrder(label == BattleOptionLabel.A ? 1 : 2)
                 .build();
         ReflectionTestUtils.setField(option, "id", id);
         return option;

--- a/src/test/java/com/swyp/picke/domain/user/service/MypageServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/user/service/MypageServiceTest.java
@@ -212,12 +212,12 @@ class MypageServiceTest {
         User user = createUser(1L, "tag");
 
         when(userService.findCurrentUser()).thenReturn(user);
-        when(voteQueryService.findUserVotes(1L, 0, 20, BattleOptionLabel.A)).thenReturn(List.of());
-        when(voteQueryService.countUserVotes(1L, BattleOptionLabel.A)).thenReturn(0L);
+        when(voteQueryService.findUserVotes(1L, 0, 20, VoteSide.PRO)).thenReturn(List.of());
+        when(voteQueryService.countUserVotes(1L, VoteSide.PRO)).thenReturn(0L);
 
         mypageService.getBattleRecords(null, null, VoteSide.PRO);
 
-        verify(voteQueryService).findUserVotes(eq(1L), eq(0), eq(20), eq(BattleOptionLabel.A));
+        verify(voteQueryService).findUserVotes(eq(1L), eq(0), eq(20), eq(VoteSide.PRO));
     }
 
     @Test
@@ -408,9 +408,9 @@ class MypageServiceTest {
     private BattleOption createOption(Battle battle, BattleOptionLabel label) {
         BattleOption option = BattleOption.builder()
                 .battle(battle)
-                .label(label)
                 .title(label.name())
                 .stance("stance-" + label.name())
+                .displayOrder(label == BattleOptionLabel.A ? 1 : 2)
                 .build();
         ReflectionTestUtils.setField(option, "id", generateId());
         return option;

--- a/src/test/java/com/swyp/picke/domain/user/service/batch/BestCommentRewardJobTest.java
+++ b/src/test/java/com/swyp/picke/domain/user/service/batch/BestCommentRewardJobTest.java
@@ -2,7 +2,6 @@ package com.swyp.picke.domain.user.service.batch;
 
 import com.swyp.picke.domain.battle.entity.Battle;
 import com.swyp.picke.domain.battle.entity.BattleOption;
-import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 import com.swyp.picke.domain.battle.enums.BattleStatus;
 import com.swyp.picke.domain.battle.repository.BattleRepository;
 import com.swyp.picke.domain.perspective.entity.Perspective;
@@ -123,9 +122,9 @@ class BestCommentRewardJobTest {
     private Perspective perspective(Long id, Battle battle, User user, int likeCount) {
         BattleOption option = BattleOption.builder()
                 .battle(battle)
-                .label(BattleOptionLabel.A)
                 .title("A")
                 .stance("stance")
+                .displayOrder(1)
                 .build();
 
         Perspective perspective = Perspective.builder()

--- a/src/test/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImplTest.java
+++ b/src/test/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImplTest.java
@@ -185,9 +185,9 @@ class BattleVoteServiceImplTest {
     private BattleOption option(Long id, Battle battle, BattleOptionLabel label) {
         BattleOption option = BattleOption.builder()
                 .battle(battle)
-                .label(label)
                 .title(label.name())
                 .stance("stance")
+                .displayOrder(label == BattleOptionLabel.A ? 1 : 2)
                 .build();
         ReflectionTestUtils.setField(option, "id", id);
         return option;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #243

## 📝 작업 내용

### ♻️ Refactor
| 내용 | 파일 |
|------|------|
| 배틀 옵션 `label` 필드 제거 및 `displayOrder` 기준 처리 전환 | `BattleOption.java`, `BattleServiceImpl.java`, `BattleOptionRepository.java` |
| 홈/추천/시나리오/마이페이지의 배틀 옵션 `label` 의존 제거 | `HomeService.java`, `RecommendationService.java`, `ScenarioServiceImpl.java`, `MypageService.java` |
| 배틀 옵션 요청/응답 `DTO`에서 `label` 제거 | `AdminBattleOptionRequest.java`, `BattleOptionResponse.java`, `TodayOptionResponse.java` |

## 📌 공유 사항
1. @Roy-wonji @yaeunjess
앱 개발자 분들과 상의 후 Merge가 필요한 부분입니다!
2. `battle_options.label` 컬럼 제거 마이그레이션이 포함되어 있습니다.
3. 관리자 통합 테스트는 로컬 `APPLE_TEAM_ID` `placeholder` 미설정 시 `Spring Context` 로딩이 막힙니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
- JUnit focused tests 통과

## 💬 리뷰 요구사항
1. `battle_options.label` 제거 이후 `displayOrder` 기반 옵션 매칭과 시나리오 `A/B` 경로 연결이 정상 동작하는지 확인 부탁드립니다.

## 🧪 검증
- `.\gradlew.bat compileJava`
- `.\gradlew.bat compileTestJava`
- 배틀 옵션 변경 경로 `focused tests` 통과