### PR TITLE
#254 [Refactor] 관점 등록/수정 시 GPT 검수 코드 제거

### DIFF
--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
@@ -92,10 +92,8 @@ public class PerspectiveService {
                 .content(request.content())
                 .build();
 
-        // 댓글 검수 비활성화 및 댓글 작성 승인
         perspective.updateStatus(PerspectiveStatus.PUBLISHED);
         Perspective saved = perspectiveRepository.save(perspective);
-        // gptModerationService.moderate(saved.getId(), saved.getContent());
         return new CreatePerspectiveResponse(saved.getId(), saved.getStatus(), saved.getCreatedAt());
     }
 
@@ -163,9 +161,7 @@ public class PerspectiveService {
         Perspective perspective = findPerspectiveById(perspectiveId);
         validateOwnership(perspective, userId);
         perspective.updateContent(request.content());
-        // 댓글 검수 미수행 및 댓글 바로 적용
         perspective.updateStatus(PerspectiveStatus.PUBLISHED);
-        // gptModerationService.moderate(perspective.getId(), perspective.getContent());
         return new UpdatePerspectiveResponse(perspective.getId(), perspective.getContent(), perspective.getUpdatedAt());
     }
 


### PR DESCRIPTION
 ## #️ 연관된 이슈
  - #254

  ## 📝 작업 내용

  ### ♻️ Refactor
  | 내용 | 파일 |
  |------|------|
  | 관점 등록/수정 시 GPT 검수 주석 코드 제거 | `PerspectiveService.java` |

  ## 📌 공유 사항
  > 1. 기존에 `createPerspective()`, `updatePerspective()`에서 GPT 검수 호출이 주석 처리된 채 남아있던 dead code를 제거했습니다. 동작 방식은 동일하게 등록/수정 즉시 `PUBLISHED` 상태로 저장됩니다.

  ## ✅  체크리스트
  - [x] Reviewer에 팀원들을 선택했나요?
  - [x] Assignees에 본인을 선택했나요?
  - [x] 컨벤션에 맞는 Type을 선택했나요?
  - [x] Development에 이슈를 연동했나요?
  - [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [x] 컨벤션을 지키고 있나요?
  - [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [x] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷
  해당 없음 (코드 정리 작업)

  ## 💬 리뷰 요구사항
  > 1. 없습니다.