### PR TITLE
#255 [Refactor] VoteStatsResponse OptionStat에 title 필드 추가

### DIFF
--- a/src/main/java/com/swyp/picke/domain/vote/dto/response/VoteStatsResponse.java
+++ b/src/main/java/com/swyp/picke/domain/vote/dto/response/VoteStatsResponse.java
@@ -10,6 +10,7 @@ public record VoteStatsResponse(
 ) {
     public record OptionStat(
             Long optionId,
+            String title,
             String imageUrl,
             long voteCount,
             double ratio

--- a/src/main/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/vote/service/BattleVoteServiceImpl.java
@@ -85,6 +85,7 @@ public class BattleVoteServiceImpl implements BattleVoteService {
                             : 0.0;
                     return new VoteStatsResponse.OptionStat(
                             option.getId(),
+                            option.getTitle(),
                             urlProvider.getImageUrl(FileCategory.PHILOSOPHER, option.getImageUrl()),
                             count,
                             ratio


### PR DESCRIPTION
## #️ 연관된 이슈
  - #255

  ## 📝 작업 내용

  ### ♻️ Refactor
  | 내용 | 파일 |
  |------|------|
  | VoteStatsResponse OptionStat에 title 필드 추가 | `VoteStatsResponse.java`, `BattleVoteServiceImpl.java` |

  ## 📌 공유 사항
  > 1. `GET /api/v1/battles/{battleId}/vote-stats` 응답의 `OptionStat`에 `title` 필드가 추가되었습니다. 옵션 이름(ex. "변기는 변기다")을 투표 % 바 및 관점 탭 구성에 활용해 주세요.
  > 2. 관점 목록 조회 시 옵션 탭 필터는 `optionId` 파라미터로 전달하면 됩니다. (`GET /api/v1/battles/{battleId}/perspectives?optionId={optionId}`)

  ## ✅  체크리스트
  - [x] Reviewer에 팀원들을 선택했나요?
  - [x] Assignees에 본인을 선택했나요?
  - [x] 컨벤션에 맞는 Type을 선택했나요?
  - [x] Development에 이슈를 연동했나요?
  - [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [x] 컨벤션을 지키고 있나요?
  - [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [x] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷
  해당 없음 (응답 필드 추가)

  ## 💬 리뷰 요구사항
  > 1. 없습니다.