### PR TITLE
#260 [Feat] 스웨거 어드민/유저 분리

### DIFF
--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminAttendanceController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminAttendanceController.java
@@ -4,7 +4,6 @@ import com.swyp.picke.domain.admin.dto.attendance.response.AdminAttendanceRespon
 import com.swyp.picke.domain.admin.dto.attendance.response.AdminAttendanceResponse.UserAttendanceResponse;
 import com.swyp.picke.domain.admin.service.AdminAttendanceService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 
-@Hidden
 @Tag(name = "관리자 출석체크 API", description = "출석 현황 집계 및 특정 유저 출석 이력 조회")
 @RestController
 @RequestMapping("/api/v1/admin/attendance")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminBattleController.java
@@ -6,7 +6,6 @@ import com.swyp.picke.domain.admin.dto.battle.response.AdminBattleDetailResponse
 import com.swyp.picke.domain.admin.dto.battle.request.AdminBattleUpdateRequest;
 import com.swyp.picke.domain.admin.service.AdminBattleService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "관리자 배틀 API", description = "관리자 배틀 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/battles")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminNotificationController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminNotificationController.java
@@ -6,7 +6,6 @@ import com.swyp.picke.domain.admin.dto.notification.response.AdminNoticeListResp
 import com.swyp.picke.domain.admin.service.AdminNotificationService;
 import com.swyp.picke.domain.notification.enums.NotificationCategory;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "관리자 공지 API", description = "공지사항/이벤트 작성 및 조회")
 @RestController
 @RequestMapping("/api/v1/admin/notices")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminPickeController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminPickeController.java
@@ -7,7 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@Hidden // 스웨거 노출 차단
+@Hidden
 @Controller
 @RequestMapping("/api/v1/admin")
 public class AdminPickeController {

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminPollController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminPollController.java
@@ -6,7 +6,6 @@ import com.swyp.picke.domain.admin.dto.poll.response.AdminPollDeleteResponse;
 import com.swyp.picke.domain.admin.dto.poll.response.AdminPollDetailResponse;
 import com.swyp.picke.domain.admin.service.AdminPollService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "관리자 투표 콘텐츠 API", description = "관리자 투표 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/polls")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminQuizController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminQuizController.java
@@ -6,7 +6,6 @@ import com.swyp.picke.domain.admin.dto.quiz.response.AdminQuizDeleteResponse;
 import com.swyp.picke.domain.admin.dto.quiz.response.AdminQuizDetailResponse;
 import com.swyp.picke.domain.admin.service.AdminQuizService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "관리자 퀴즈 API", description = "관리자 퀴즈 콘텐츠 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin/quizzes")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminScenarioController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminScenarioController.java
@@ -8,7 +8,6 @@ import com.swyp.picke.domain.admin.dto.scenario.response.AdminScenarioDetailResp
 import com.swyp.picke.domain.admin.dto.scenario.response.AdminScenarioResponse;
 import com.swyp.picke.domain.admin.service.AdminScenarioService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "관리자 시나리오 API", description = "관리자 시나리오 생성, 조회, 수정, 삭제")
 @RestController
 @RequestMapping("/api/v1/admin")

--- a/src/main/java/com/swyp/picke/domain/admin/controller/AdminTagController.java
+++ b/src/main/java/com/swyp/picke/domain/admin/controller/AdminTagController.java
@@ -5,7 +5,6 @@ import com.swyp.picke.domain.admin.dto.tag.response.TagDeleteResponse;
 import com.swyp.picke.domain.admin.dto.tag.response.TagResponse;
 import com.swyp.picke.domain.admin.service.AdminTagService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "관리자 태그 API", description = "관리자 태그 생성, 수정, 삭제")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/swyp/picke/domain/battle/controller/AdminBattleProposalController.java
+++ b/src/main/java/com/swyp/picke/domain/battle/controller/AdminBattleProposalController.java
@@ -4,7 +4,6 @@ import com.swyp.picke.domain.battle.dto.response.BattleProposalResponse;
 import com.swyp.picke.domain.battle.dto.request.BattleProposalReviewRequest;
 import com.swyp.picke.domain.battle.service.BattleProposalService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-@Hidden
 @Tag(name = "관리자 배틀 제안 API", description = "주제 제안 목록 조회 및 채택/미채택 처리")
 @RestController
 @RequestMapping("/api/v1/admin/battles")

--- a/src/main/java/com/swyp/picke/domain/perspective/controller/BestCommentSchedulerTestController.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/controller/BestCommentSchedulerTestController.java
@@ -2,7 +2,6 @@ package com.swyp.picke.domain.perspective.controller;
 
 import com.swyp.picke.domain.perspective.scheduler.BestCommentScheduler;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Hidden
 @Tag(name = "[Test] BestCommentScheduler", description = "스케줄러 테스트 API")
 @RestController
 @RequestMapping("/api/test/scheduler")

--- a/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
+++ b/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
@@ -4,7 +4,6 @@ import com.swyp.picke.domain.reward.dto.request.AdMobRewardRequest;
 import com.swyp.picke.domain.reward.dto.response.AdMobRewardResponse;
 import com.swyp.picke.domain.reward.service.AdMobRewardService;
 import com.swyp.picke.global.common.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Hidden
 @Tag(name = "보상 API", description = "AdMob 광고 보상 관련 API")
 @RestController
 @RequestMapping("/api/v1/admob")

--- a/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/swyp/picke/domain/vote/controller/VoteController.java
@@ -145,7 +145,6 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Hidden
     @Operation(summary = "[관리자] 배틀 투표 기록 삭제")
     @DeleteMapping("/admin/votes/battle/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -154,7 +153,6 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Hidden
     @Operation(summary = "[관리자] 퀴즈 투표 기록 삭제")
     @DeleteMapping("/admin/votes/quiz/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")
@@ -163,7 +161,6 @@ public class VoteController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Hidden
     @Operation(summary = "[관리자] 투표 콘텐츠 투표 기록 삭제")
     @DeleteMapping("/admin/votes/poll/{battleId}")
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/swyp/picke/global/config/SwaggerConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/SwaggerConfig.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -80,6 +81,32 @@ public class SwaggerConfig {
     );
 
     @Bean
+    public GroupedOpenApi userApi() {
+        return GroupedOpenApi.builder()
+                .group("1. 사용자 API")
+                .pathsToMatch("/api/v1/**")
+                .pathsToExclude("/api/v1/admin/**", "/api/v1/files/**", "/api/v1/resources/**", "/api/test/**", "/api/v1/admob/**")
+                .addOpenApiCustomizer(feUsedApiOnlyCustomizer())
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("2. 관리자 API")
+                .pathsToMatch("/api/v1/admin/**", "/api/v1/files/**", "/api/v1/resources/**", "/api/test/**", "/api/v1/admob/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi allApi() {
+        return GroupedOpenApi.builder()
+                .group("0. 모든 API")
+                .pathsToMatch("/api/**")
+                .build();
+    }
+
+    @Bean
     public OpenAPI openAPI() {
         // 1. 운영 서버 (8080)
         Server prodServer = new Server()
@@ -118,7 +145,6 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement);
     }
 
-    @Bean
     public OpenApiCustomizer feUsedApiOnlyCustomizer() {
         return openApi -> {
             if (openApi.getPaths() == null) {

--- a/src/main/java/com/swyp/picke/global/infra/s3/controller/FileUploadController.java
+++ b/src/main/java/com/swyp/picke/global/infra/s3/controller/FileUploadController.java
@@ -6,7 +6,6 @@ import com.swyp.picke.global.infra.s3.dto.FileUploadResponse;
 import com.swyp.picke.global.infra.s3.enums.FileCategory;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
 import com.swyp.picke.global.infra.s3.service.S3UploadService;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 
-@Hidden
 @Tag(name = "파일 업로드 API", description = "관리자 파일 업로드 (S3 / 로컬 임시저장)")
 @RestController
 @RequestMapping("/api/v1/files")

--- a/src/main/java/com/swyp/picke/global/infra/s3/controller/ResourceRedirectController.java
+++ b/src/main/java/com/swyp/picke/global/infra/s3/controller/ResourceRedirectController.java
@@ -3,7 +3,6 @@ package com.swyp.picke.global.infra.s3.controller;
 import com.swyp.picke.global.infra.local.service.LocalDraftFileStorageService;
 import com.swyp.picke.global.infra.s3.enums.FileCategory;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
-@Hidden
 @Tag(name = "리소스 리다이렉트 API", description = "공개 리소스 요청을 S3 Presigned URL 또는 로컬 임시파일로 전달")
 @RestController
 @RequestMapping("/api/v1/resources")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- closed #260 

## 📝 작업 내용

### ✨ Feat
| 내용 | 파일 |
|------|------|
| 스웨거 API 그룹화 기능 구현 (사용자 / 관리자 / 모든 API) | `SwaggerConfig.java` |
| 관리자 권한 API의 스웨거 노출 작업 (`@Hidden` 제거) | `AdminBattleController.java`, `AdminQuizController.java` 외 11개 파일 |
| AdMob 보상 콜백 및 테스트용 API 관리자 그룹 편성 | `SwaggerConfig.java`, `AdMobRewardController.java`, `BestCommentSchedulerTestController.java` |

### ♻️ Refactor
| 내용 | 파일 |
|------|------|
| 사용자 API 필터링 로직을 사용자 그룹에만 선택적으로 적용하도록 개선 | `SwaggerConfig.java` |
| 스웨거 그룹명을 URL 친화적인 형식으로 최적화 (공백 및 마침표 제거) | `SwaggerConfig.java` |

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| HTML 템플릿을 반환하는 어드민 뷰 컨트롤러의 스웨거 노출 차단 | `AdminPickeController.java` |

## 📌 공유 사항
> - 스웨거 UI 상단 드롭다운에서 **1_사용자_API**, **2_관리자_API**를 선택하여 구분된 명세를 확인할 수 있습니다.
> - `AdMob` 관련 콜백 API와 `Test` 스케줄러 API는 관리자 그룹으로 분류되었습니다.
> - 프론트엔드 화이트리스트 필터링 로직은 **1_사용자_API** 그룹에만 적용됩니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
<!-- Swagger, Postman, JUnit 테스트 화면 첨부 -->
> 사용자 스웨거
<img width="1424" height="754" alt="image" src="https://github.com/user-attachments/assets/c9844eb4-c991-436f-94bc-86d0034a2c19" />

> 관리자 스웨거
<img width="1423" height="754" alt="image" src="https://github.com/user-attachments/assets/5dd92322-b062-42f7-8516-9a8c7412074c" />


## 💬 리뷰 요구사항
> - `SwaggerConfig`에서 `OpenApiCustomizer`를 전역 빈이 아닌 특정 그룹에만 수동 적용한 방식이 그룹별 정책 분리에 적합한지 검토 부탁드립니다.
> - 현재 관리자 그룹으로 분류된 경로(`admin/**`, `files/**`, `admob/**`, `test/**`)가 적절한지 의견 부탁드립니다.
