### PR TITLE
[Feat] 알림기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,11 @@ dependencies {
     // Google Cloud TTS
     implementation 'com.google.cloud:google-cloud-texttospeech:2.58.0'
 
-    // Firebase Admin SDK (FCM 푸시 알림)
+    // Firebase Admin SDK (FCM 푸시 알림 - Android)
     implementation 'com.google.firebase:firebase-admin:9.9.0'
+
+    // Pushy (다이렉트 APNs 푸시 알림 - iOS)
+    implementation 'com.eatthepath:pushy:0.15.4'
 
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     // Google Cloud TTS
     implementation 'com.google.cloud:google-cloud-texttospeech:2.58.0'
 
+    // Firebase Admin SDK (FCM 푸시 알림)
+    implementation 'com.google.firebase:firebase-admin:9.9.0'
+
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
 

--- a/docs/api-specs/notification-api.md
+++ b/docs/api-specs/notification-api.md
@@ -1,0 +1,311 @@
+# 알림 API 명세서 (인앱 알림 + FCM 푸시)
+
+---
+
+## 1. 설계 메모
+
+- 알림은 **인앱 알림(알림함)** 과 **FCM 푸시**, 두 트랙으로 동작합니다.
+  - 인앱 알림: `GET /api/v1/notifications`로 조회하는 알림함 데이터
+  - FCM 푸시: 앱이 백그라운드/종료 상태일 때 기기로 직접 발송되는 푸시
+- **NEW_BATTLE / COMMENT_LIKE / NEW_COMMENT** 는 인앱 알림 + FCM 푸시 둘 다 발송됩니다.
+- **CREDIT_EARNED / POLICY_CHANGE / PROMOTION** 은 인앱 알림만 발송됩니다 (푸시 없음).
+- **VOTE_RESULT** 는 현재 보류 상태로, 발생하지 않습니다.
+- 인증이 필요한 모든 API는 `Authorization: Bearer {access_token}` 헤더를 요구합니다.
+- ⚠️ 이 도메인의 응답/요청 필드는 다른 API 문서(`snake_case`)와 달리 **`camelCase`** 입니다. (예: `notificationId`, `referenceId`, `perspectiveId`, `isRead`, `fcmToken`)
+
+### 1.1 `NotificationCategory`
+
+| 값 | 설명 |
+|---|---|
+| `ALL` | 전체 (목록 조회 시 필터 없음과 동일) |
+| `CONTENT` | 콘텐츠 알림 (배틀, 답글 좋아요/댓글, 포인트 적립) |
+| `NOTICE` | 공지사항 |
+| `EVENT` | 이벤트/프로모션 |
+
+### 1.2 `detailCode` 목록
+
+| detailCode | category | 기본 title | 채널 | referenceId 의미 | perspectiveId |
+|---|---|---|---|---|---|
+| `NEW_BATTLE` | CONTENT | 새로운 배틀이 시작되었어요 | 인앱 + 푸시 | battleId | - |
+| `COMMENT_LIKE` | CONTENT | 내 답글에 좋아요가 달렸어요 | 인앱 + 푸시 | commentId | perspectiveId |
+| `NEW_COMMENT` | CONTENT | 내 답글에 댓글이 달렸어요 | 인앱 + 푸시 | commentId | perspectiveId |
+| `CREDIT_EARNED` | CONTENT | 포인트 적립 | 인앱만 | 적립 종류별로 다름(아래 참고) | - |
+| `POLICY_CHANGE` | NOTICE | 공지사항 | 인앱만 | 없음(`null`) | - |
+| `PROMOTION` | EVENT | 이벤트 | 인앱만 | 없음(`null`) | - |
+| `VOTE_RESULT` | CONTENT | 투표 결과가 나왔어요 | (보류, 미발생) | - | - |
+
+`CREDIT_EARNED`의 `referenceId`는 적립 트리거에 따라 배틀 ID, 투표 ID, 제안 ID 등으로 다양하게 들어갈 수 있어 클라이언트에서 별도 화면 이동에 사용하지 않는 것을 권장합니다. `title`/`body` 텍스트만 표시하면 됩니다.
+
+---
+
+## 2. 디바이스(FCM 토큰) 등록/해제 API
+
+### 2.1 `POST /api/v1/devices`
+
+로그인 성공 직후, 또는 FCM 토큰이 갱신될 때(`onNewToken` 등) 호출합니다. 이미 등록된 토큰이면 현재 로그인한 유저로 재할당됩니다(같은 기기에서 계정을 바꿔 로그인하는 경우 대응).
+
+요청 헤더:
+
+- `Authorization: Bearer {access_token}`
+
+요청 바디:
+
+```json
+{
+  "fcmToken": "fcm_device_token_string",
+  "platform": "ANDROID"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `fcmToken` | `string` | Y | FCM 디바이스 토큰 |
+| `platform` | `string` | Y | `ANDROID` \| `IOS` |
+
+성공 응답 `200 OK`:
+
+```json
+{
+  "statusCode": 200,
+  "data": null,
+  "error": null
+}
+```
+
+---
+
+### 2.2 `DELETE /api/v1/devices`
+
+로그아웃 시 호출합니다. 등록되어 있지 않은 토큰을 보내도 에러 없이 `200`을 반환합니다(idempotent).
+
+요청 헤더:
+
+- `Authorization: Bearer {access_token}`
+
+쿼리 파라미터:
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `fcmToken` | `string` | Y | 해제할 FCM 디바이스 토큰 |
+
+성공 응답 `200 OK`:
+
+```json
+{
+  "statusCode": 200,
+  "data": null,
+  "error": null
+}
+```
+
+---
+
+## 3. 알림함 API
+
+### 3.1 `GET /api/v1/notifications`
+
+알림함 목록을 최신순으로 조회합니다.
+
+요청 헤더:
+
+- `Authorization: Bearer {access_token}`
+
+쿼리 파라미터:
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---|---|---|---|
+| `category` | `string` | N | `ALL` \| `CONTENT` \| `NOTICE` \| `EVENT` (생략 시 전체) |
+| `page` | `integer` | N | 페이지 번호 (기본값 `0`) |
+| `size` | `integer` | N | 페이지 크기 (기본값 `20`) |
+
+성공 응답 `200 OK`:
+
+```json
+{
+  "statusCode": 200,
+  "data": {
+    "items": [
+      {
+        "notificationId": 101,
+        "category": "CONTENT",
+        "detailCode": "NEW_BATTLE",
+        "title": "새로운 배틀이 시작되었어요",
+        "body": "\"민트초코, 호불호의 끝판왕\"에 지금 참여해보세요!",
+        "referenceId": 55,
+        "perspectiveId": null,
+        "isRead": false,
+        "createdAt": "2026-06-10T09:00:00"
+      },
+      {
+        "notificationId": 100,
+        "category": "CONTENT",
+        "detailCode": "COMMENT_LIKE",
+        "title": "내 답글에 좋아요가 달렸어요",
+        "body": "\"민트초코, 호불호의 끝판왕\" 배틀에 남긴 내 답글에 좋아요가 달렸어요.",
+        "referenceId": 678,
+        "perspectiveId": 45,
+        "isRead": true,
+        "createdAt": "2026-06-09T18:30:00"
+      }
+    ],
+    "hasNext": false
+  },
+  "error": null
+}
+```
+
+탭(클릭) 시 화면 이동 로직은 [5. detailCode별 처리 가이드](#5-detailcode별-처리-가이드) 참고.
+
+---
+
+### 3.2 `GET /api/v1/notifications/{notificationId}`
+
+알림 상세를 조회합니다. (목록과 동일한 필드 + `readAt`)
+
+요청 헤더:
+
+- `Authorization: Bearer {access_token}`
+
+성공 응답 `200 OK`:
+
+```json
+{
+  "statusCode": 200,
+  "data": {
+    "notificationId": 100,
+    "category": "CONTENT",
+    "detailCode": "COMMENT_LIKE",
+    "title": "내 답글에 좋아요가 달렸어요",
+    "body": "\"민트초코, 호불호의 끝판왕\" 배틀에 남긴 내 답글에 좋아요가 달렸어요.",
+    "referenceId": 678,
+    "perspectiveId": 45,
+    "isRead": true,
+    "createdAt": "2026-06-09T18:30:00",
+    "readAt": "2026-06-09T19:00:00"
+  },
+  "error": null
+}
+```
+
+예외 응답 `404 - 알림 없음`:
+
+```json
+{
+  "statusCode": 404,
+  "data": null,
+  "error": {
+    "code": "NOTIFICATION_404",
+    "message": "존재하지 않는 알림입니다."
+  }
+}
+```
+
+---
+
+### 3.3 `PATCH /api/v1/notifications/{notificationId}/read`
+
+알림 1건을 읽음 처리합니다.
+
+요청 헤더:
+
+- `Authorization: Bearer {access_token}`
+
+성공 응답 `200 OK`:
+
+```json
+{
+  "statusCode": 200,
+  "data": null,
+  "error": null
+}
+```
+
+---
+
+### 3.4 `PATCH /api/v1/notifications/read-all`
+
+알림함의 모든 알림을 읽음 처리합니다.
+
+요청 헤더:
+
+- `Authorization: Bearer {access_token}`
+
+성공 응답 `200 OK`:
+
+```json
+{
+  "statusCode": 200,
+  "data": null,
+  "error": null
+}
+```
+
+---
+
+## 4. FCM 푸시 처리 가이드 (Android / iOS)
+
+`NEW_BATTLE`, `COMMENT_LIKE`, `NEW_COMMENT` 발생 시 등록된 디바이스로 FCM 메시지가 발송됩니다. 플랫폼별 메시지 구성이 다르므로 주의해주세요.
+
+### 4.1 Android
+
+- **data-only** 메시지로 발송됩니다 (notification 블록 없음).
+- 앱이 직접 `data`를 파싱해 로컬 알림(Notification)을 생성하고, 알림 탭 시에도 `data`로 라우팅을 처리해야 합니다.
+
+### 4.2 iOS
+
+- **notification + data** 메시지로 발송됩니다.
+- OS가 자동으로 알림을 표시합니다. 알림 탭 시 `data` 페이로드(또는 `url`의 유니버설 링크)로 라우팅합니다.
+- `apple-app-site-association`이 `paths: ["*"]` 와일드카드로 설정되어 있어, `url`에 포함된 모든 경로가 유니버설 링크로 동작합니다. 별도 서버 설정 변경 없이 사용 가능합니다.
+
+### 4.3 `data` 페이로드 포맷
+
+**NEW_BATTLE**
+
+```json
+{
+  "type": "BATTLE",
+  "battleId": "55",
+  "url": "https://picke.store/battle/55"
+}
+```
+
+**COMMENT_LIKE / NEW_COMMENT**
+
+```json
+{
+  "type": "COMMENT",
+  "perspectiveId": "45",
+  "commentId": "678",
+  "url": "https://picke.store/perspective/45?commentId=678"
+}
+```
+
+> `data`의 모든 값은 FCM 규격상 문자열(string)입니다. ID 값을 정수로 파싱해서 사용해주세요.
+
+탭 시 `type` 값으로 분기:
+
+- `"BATTLE"` → `battleId`로 배틀 상세 화면 이동
+- `"COMMENT"` → `perspectiveId`로 관점(댓글) 화면 이동 후 `commentId` 위치로 스크롤/하이라이트
+
+푸시 데이터에는 알림함의 `notificationId`가 포함되어 있지 않습니다. 푸시 탭 후 별도로 읽음 처리가 필요하면 알림함 목록에서 동일 `referenceId`/`perspectiveId`를 가진 항목을 찾아 `PATCH /api/v1/notifications/{notificationId}/read`를 호출해주세요.
+
+---
+
+## 5. detailCode별 처리 가이드
+
+| detailCode | 탭(클릭) 시 동작 |
+|---|---|
+| `NEW_BATTLE` | `referenceId`(=battleId)로 배틀 상세 화면 이동 |
+| `COMMENT_LIKE` / `NEW_COMMENT` | `perspectiveId`로 관점 화면 이동 후 `referenceId`(=commentId) 위치로 스크롤/하이라이트 |
+| `CREDIT_EARNED` | 별도 이동 없음. `title` / `body` 텍스트만 표시 |
+| `POLICY_CHANGE` / `PROMOTION` | 별도 이동 없음. `title` / `body` 텍스트만 표시 |
+
+---
+
+## 6. 에러 코드
+
+| Error Code | HTTP Status | 설명 |
+|---|:---:|---|
+| `COMMON_400` | `400` | 요청 파라미터가 잘못되었습니다. (예: `fcmToken`/`platform` 누락) |
+| `USER_404` | `404` | 존재하지 않는 사용자입니다. |
+| `NOTIFICATION_404` | `404` | 존재하지 않는 알림입니다. (본인 소유가 아닌 알림 포함) |

--- a/docs/api-specs/notification-api.md
+++ b/docs/api-specs/notification-api.md
@@ -1,13 +1,13 @@
-# 알림 API 명세서 (인앱 알림 + FCM 푸시)
+# 알림 API 명세서 (인앱 알림 + 푸시)
 
 ---
 
 ## 1. 설계 메모
 
-- 알림은 **인앱 알림(알림함)** 과 **FCM 푸시**, 두 트랙으로 동작합니다.
+- 알림은 **인앱 알림(알림함)** 과 **푸시**, 두 트랙으로 동작합니다.
   - 인앱 알림: `GET /api/v1/notifications`로 조회하는 알림함 데이터
-  - FCM 푸시: 앱이 백그라운드/종료 상태일 때 기기로 직접 발송되는 푸시
-- **NEW_BATTLE / COMMENT_LIKE / NEW_COMMENT** 는 인앱 알림 + FCM 푸시 둘 다 발송됩니다.
+  - 푸시: 앱이 백그라운드/종료 상태일 때 기기로 직접 발송되는 푸시. Android는 FCM, iOS는 APNs로 직접 발송됩니다.
+- **NEW_BATTLE / COMMENT_LIKE / NEW_COMMENT** 는 인앱 알림 + 푸시 둘 다 발송됩니다.
 - **CREDIT_EARNED / POLICY_CHANGE / PROMOTION** 은 인앱 알림만 발송됩니다 (푸시 없음).
 - **VOTE_RESULT** 는 현재 보류 상태로, 발생하지 않습니다.
 - 인증이 필요한 모든 API는 `Authorization: Bearer {access_token}` 헤더를 요구합니다.
@@ -38,11 +38,11 @@
 
 ---
 
-## 2. 디바이스(FCM 토큰) 등록/해제 API
+## 2. 디바이스(푸시 토큰) 등록/해제 API
 
 ### 2.1 `POST /api/v1/devices`
 
-로그인 성공 직후, 또는 FCM 토큰이 갱신될 때(`onNewToken` 등) 호출합니다. 이미 등록된 토큰이면 현재 로그인한 유저로 재할당됩니다(같은 기기에서 계정을 바꿔 로그인하는 경우 대응).
+로그인 성공 직후, 또는 푸시 토큰이 갱신될 때 호출합니다. 이미 등록된 토큰이면 현재 로그인한 유저로 재할당됩니다(같은 기기에서 계정을 바꿔 로그인하는 경우 대응).
 
 요청 헤더:
 
@@ -52,14 +52,14 @@
 
 ```json
 {
-  "fcmToken": "fcm_device_token_string",
+  "fcmToken": "device_push_token_string",
   "platform": "ANDROID"
 }
 ```
 
 | 필드 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| `fcmToken` | `string` | Y | FCM 디바이스 토큰 |
+| `fcmToken` | `string` | Y | `platform=ANDROID`이면 FCM 토큰, `platform=IOS`이면 APNs 디바이스 토큰(`didRegisterForRemoteNotificationsWithDeviceToken`에서 받은 토큰을 hex 문자열로 변환한 값) |
 | `platform` | `string` | Y | `ANDROID` \| `IOS` |
 
 성공 응답 `200 OK`:
@@ -86,7 +86,7 @@
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| `fcmToken` | `string` | Y | 해제할 FCM 디바이스 토큰 |
+| `fcmToken` | `string` | Y | 해제할 디바이스 푸시 토큰 |
 
 성공 응답 `200 OK`:
 
@@ -242,20 +242,22 @@
 
 ---
 
-## 4. FCM 푸시 처리 가이드 (Android / iOS)
+## 4. 푸시 처리 가이드 (Android: FCM / iOS: APNs)
 
-`NEW_BATTLE`, `COMMENT_LIKE`, `NEW_COMMENT` 발생 시 등록된 디바이스로 FCM 메시지가 발송됩니다. 플랫폼별 메시지 구성이 다르므로 주의해주세요.
+`NEW_BATTLE`, `COMMENT_LIKE`, `NEW_COMMENT` 발생 시 등록된 디바이스로 푸시가 발송됩니다. Android는 FCM, iOS는 FCM을 거치지 않고 APNs로 직접 발송되며, 플랫폼별 메시지 구성이 다르므로 주의해주세요.
 
-### 4.1 Android
+### 4.1 Android (FCM)
 
 - **data-only** 메시지로 발송됩니다 (notification 블록 없음).
 - 앱이 직접 `data`를 파싱해 로컬 알림(Notification)을 생성하고, 알림 탭 시에도 `data`로 라우팅을 처리해야 합니다.
 
-### 4.2 iOS
+### 4.2 iOS (APNs 직접 발송)
 
-- **notification + data** 메시지로 발송됩니다.
-- OS가 자동으로 알림을 표시합니다. 알림 탭 시 `data` 페이로드(또는 `url`의 유니버설 링크)로 라우팅합니다.
+- FCM을 거치지 않고 서버가 APNs로 직접 발송하는 **alert(`aps.alert`) + 커스텀 데이터** 페이로드입니다. 커스텀 데이터(`type`, `battleId`, `url` 등)는 `aps`와 동일 레벨의 top-level 키로 들어갑니다.
+- OS가 자동으로 알림을 표시합니다. 알림 탭 시 `userInfo`의 커스텀 키(또는 `url`의 유니버설 링크)로 라우팅합니다.
 - `apple-app-site-association`이 `paths: ["*"]` 와일드카드로 설정되어 있어, `url`에 포함된 모든 경로가 유니버설 링크로 동작합니다. 별도 서버 설정 변경 없이 사용 가능합니다.
+- **Firebase SDK가 더 이상 필요하지 않습니다.** 디바이스 등록 시 보내는 토큰은 FCM 토큰이 아니라 `didRegisterForRemoteNotificationsWithDeviceToken`에서 받는 APNs 디바이스 토큰(hex 문자열)입니다.
+- 서버의 APNs 환경(sandbox/production)은 전역 설정 1개로 고정됩니다. 개발/TestFlight 빌드(sandbox 토큰)와 App Store 빌드(production 토큰)를 동시에 지원하려면 별도 협의가 필요합니다.
 
 ### 4.3 `data` 페이로드 포맷
 

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -19,6 +19,7 @@ import com.swyp.picke.domain.battle.repository.BattleOptionRepository;
 import com.swyp.picke.domain.battle.repository.BattleOptionTagRepository;
 import com.swyp.picke.domain.battle.repository.BattleRepository;
 import com.swyp.picke.domain.battle.repository.BattleTagRepository;
+import com.swyp.picke.domain.notification.service.NotificationDispatchService;
 import com.swyp.picke.domain.scenario.entity.Scenario;
 import com.swyp.picke.domain.scenario.enums.ScenarioStatus;
 import com.swyp.picke.domain.scenario.repository.ScenarioRepository;
@@ -82,6 +83,7 @@ public class BattleServiceImpl implements BattleService {
     private final BattleAutoSeedService battleAutoSeedService;
     private final ScenarioRepository scenarioRepository;
     private final ScenarioAudioPipelineService scenarioAudioPipelineService;
+    private final NotificationDispatchService notificationDispatchService;
 
     @Override
     public Battle findById(Long battleId) {
@@ -517,6 +519,7 @@ public class BattleServiceImpl implements BattleService {
                 publishBattleAssets(battle);
                 battle.publish();
                 publishScenarioIfPresent(battle);
+                notifyNewBattleAfterCommit(battle);
             }
 
             openedCount += readyPage.getNumberOfElements();
@@ -574,6 +577,22 @@ public class BattleServiceImpl implements BattleService {
                     scenario.updateStatus(ScenarioStatus.PUBLISHED);
                     triggerScenarioAudioAfterCommit(scenario);
                 });
+    }
+
+    private void notifyNewBattleAfterCommit(Battle battle) {
+        Long battleId = battle.getId();
+        String title = battle.getTitle();
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    notificationDispatchService.notifyNewBattle(battleId, title);
+                }
+            });
+            return;
+        }
+
+        notificationDispatchService.notifyNewBattle(battleId, title);
     }
 
     private void triggerScenarioAudioAfterCommit(Scenario scenario) {

--- a/src/main/java/com/swyp/picke/domain/notification/controller/DeviceController.java
+++ b/src/main/java/com/swyp/picke/domain/notification/controller/DeviceController.java
@@ -1,0 +1,45 @@
+package com.swyp.picke.domain.notification.controller;
+
+import com.swyp.picke.domain.notification.dto.request.RegisterDeviceRequest;
+import com.swyp.picke.domain.notification.service.DeviceService;
+import com.swyp.picke.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "디바이스 API", description = "푸시 알림을 위한 FCM 디바이스 토큰 등록/해제")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/devices")
+public class DeviceController {
+
+    private final DeviceService deviceService;
+
+    @Operation(summary = "FCM 디바이스 토큰 등록", description = "로그인 또는 토큰 갱신 시 FCM 토큰을 등록합니다.")
+    @PostMapping
+    public ApiResponse<Void> registerDevice(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid RegisterDeviceRequest request
+    ) {
+        deviceService.registerDevice(userId, request);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "FCM 디바이스 토큰 해제", description = "로그아웃 시 FCM 토큰을 해제합니다.")
+    @DeleteMapping
+    public ApiResponse<Void> unregisterDevice(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam String fcmToken
+    ) {
+        deviceService.unregisterDevice(userId, fcmToken);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/notification/controller/DeviceController.java
+++ b/src/main/java/com/swyp/picke/domain/notification/controller/DeviceController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "디바이스 API", description = "푸시 알림을 위한 FCM 디바이스 토큰 등록/해제")
+@Tag(name = "디바이스 API", description = "푸시 알림을 위한 디바이스 토큰 등록/해제 (Android: FCM 토큰, iOS: APNs 디바이스 토큰)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/devices")
@@ -23,7 +23,7 @@ public class DeviceController {
 
     private final DeviceService deviceService;
 
-    @Operation(summary = "FCM 디바이스 토큰 등록", description = "로그인 또는 토큰 갱신 시 FCM 토큰을 등록합니다.")
+    @Operation(summary = "디바이스 푸시 토큰 등록", description = "로그인 또는 토큰 갱신 시 푸시 토큰을 등록합니다. Android는 FCM 토큰, iOS는 APNs 디바이스 토큰을 전달합니다.")
     @PostMapping
     public ApiResponse<Void> registerDevice(
             @AuthenticationPrincipal Long userId,
@@ -33,7 +33,7 @@ public class DeviceController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "FCM 디바이스 토큰 해제", description = "로그아웃 시 FCM 토큰을 해제합니다.")
+    @Operation(summary = "디바이스 푸시 토큰 해제", description = "로그아웃 시 푸시 토큰을 해제합니다.")
     @DeleteMapping
     public ApiResponse<Void> unregisterDevice(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/swyp/picke/domain/notification/dto/request/RegisterDeviceRequest.java
+++ b/src/main/java/com/swyp/picke/domain/notification/dto/request/RegisterDeviceRequest.java
@@ -4,6 +4,10 @@ import com.swyp.picke.domain.notification.enums.DevicePlatform;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+/**
+ * 푸시 토큰 등록 요청.
+ * platform=ANDROID이면 FCM 토큰, platform=IOS이면 APNs 디바이스 토큰을 fcmToken에 담아 전달한다.
+ */
 public record RegisterDeviceRequest(
         @NotBlank
         String fcmToken,

--- a/src/main/java/com/swyp/picke/domain/notification/dto/request/RegisterDeviceRequest.java
+++ b/src/main/java/com/swyp/picke/domain/notification/dto/request/RegisterDeviceRequest.java
@@ -1,0 +1,13 @@
+package com.swyp.picke.domain.notification.dto.request;
+
+import com.swyp.picke.domain.notification.enums.DevicePlatform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterDeviceRequest(
+        @NotBlank
+        String fcmToken,
+
+        @NotNull
+        DevicePlatform platform
+) {}

--- a/src/main/java/com/swyp/picke/domain/notification/dto/response/NotificationDetailResponse.java
+++ b/src/main/java/com/swyp/picke/domain/notification/dto/response/NotificationDetailResponse.java
@@ -11,6 +11,7 @@ public record NotificationDetailResponse(
         String title,
         String body,
         Long referenceId,
+        Long perspectiveId,
         boolean isRead,
         LocalDateTime createdAt,
         LocalDateTime readAt

--- a/src/main/java/com/swyp/picke/domain/notification/dto/response/NotificationSummaryResponse.java
+++ b/src/main/java/com/swyp/picke/domain/notification/dto/response/NotificationSummaryResponse.java
@@ -11,6 +11,7 @@ public record NotificationSummaryResponse(
         String title,
         String body,
         Long referenceId,
+        Long perspectiveId,
         boolean isRead,
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/swyp/picke/domain/notification/entity/Notification.java
+++ b/src/main/java/com/swyp/picke/domain/notification/entity/Notification.java
@@ -46,6 +46,9 @@ public class Notification extends BaseEntity {
     @Column(name = "reference_id")
     private Long referenceId;
 
+    @Column(name = "perspective_id")
+    private Long perspectiveId;
+
     @Column(name = "is_read", nullable = false)
     private boolean read;
 
@@ -54,13 +57,14 @@ public class Notification extends BaseEntity {
 
     @Builder
     private Notification(User user, NotificationCategory category, NotificationDetailCode detailCode,
-                         String title, String body, Long referenceId) {
+                         String title, String body, Long referenceId, Long perspectiveId) {
         this.user = user;
         this.category = category;
         this.detailCode = detailCode;
         this.title = title;
         this.body = body;
         this.referenceId = referenceId;
+        this.perspectiveId = perspectiveId;
         this.read = false;
     }
 

--- a/src/main/java/com/swyp/picke/domain/notification/entity/UserDevice.java
+++ b/src/main/java/com/swyp/picke/domain/notification/entity/UserDevice.java
@@ -1,0 +1,54 @@
+package com.swyp.picke.domain.notification.entity;
+
+import com.swyp.picke.domain.notification.enums.DevicePlatform;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "user_devices")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDevice extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "fcm_token", nullable = false, unique = true, length = 255)
+    private String fcmToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private DevicePlatform platform;
+
+    @Column(name = "last_used_at", nullable = false)
+    private LocalDateTime lastUsedAt;
+
+    @Builder
+    private UserDevice(User user, String fcmToken, DevicePlatform platform) {
+        this.user = user;
+        this.fcmToken = fcmToken;
+        this.platform = platform;
+        this.lastUsedAt = LocalDateTime.now();
+    }
+
+    public void reassign(User user, DevicePlatform platform) {
+        this.user = user;
+        this.platform = platform;
+        this.lastUsedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/notification/enums/DevicePlatform.java
+++ b/src/main/java/com/swyp/picke/domain/notification/enums/DevicePlatform.java
@@ -1,0 +1,6 @@
+package com.swyp.picke.domain.notification.enums;
+
+public enum DevicePlatform {
+    ANDROID,
+    IOS
+}

--- a/src/main/java/com/swyp/picke/domain/notification/enums/NotificationDetailCode.java
+++ b/src/main/java/com/swyp/picke/domain/notification/enums/NotificationDetailCode.java
@@ -7,10 +7,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationDetailCode {
 
-    // CONTENT (1~3)
+    // CONTENT (1~3, 6~7)
     NEW_BATTLE(1, NotificationCategory.CONTENT, "새로운 배틀이 시작되었어요"),
     VOTE_RESULT(2, NotificationCategory.CONTENT, "투표 결과가 나왔어요"),
     CREDIT_EARNED(3, NotificationCategory.CONTENT, "포인트 적립"),
+    COMMENT_LIKE(6, NotificationCategory.CONTENT, "내 답글에 좋아요가 달렸어요"),
+    NEW_COMMENT(7, NotificationCategory.CONTENT, "내 답글에 댓글이 달렸어요"),
 
     // NOTICE (4)
     POLICY_CHANGE(4, NotificationCategory.NOTICE, "공지사항"),

--- a/src/main/java/com/swyp/picke/domain/notification/repository/UserDeviceRepository.java
+++ b/src/main/java/com/swyp/picke/domain/notification/repository/UserDeviceRepository.java
@@ -11,6 +11,8 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     Optional<UserDevice> findByFcmToken(String fcmToken);
 
+    List<UserDevice> findAllByUserId(Long userId);
+
     List<UserDevice> findAllByUserIdAndPlatform(Long userId, DevicePlatform platform);
 
     void deleteByUserIdAndFcmToken(Long userId, String fcmToken);

--- a/src/main/java/com/swyp/picke/domain/notification/repository/UserDeviceRepository.java
+++ b/src/main/java/com/swyp/picke/domain/notification/repository/UserDeviceRepository.java
@@ -1,0 +1,17 @@
+package com.swyp.picke.domain.notification.repository;
+
+import com.swyp.picke.domain.notification.entity.UserDevice;
+import com.swyp.picke.domain.notification.enums.DevicePlatform;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+    Optional<UserDevice> findByFcmToken(String fcmToken);
+
+    List<UserDevice> findAllByUserIdAndPlatform(Long userId, DevicePlatform platform);
+
+    void deleteByUserIdAndFcmToken(Long userId, String fcmToken);
+}

--- a/src/main/java/com/swyp/picke/domain/notification/service/DeviceService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/DeviceService.java
@@ -1,0 +1,44 @@
+package com.swyp.picke.domain.notification.service;
+
+import com.swyp.picke.domain.notification.dto.request.RegisterDeviceRequest;
+import com.swyp.picke.domain.notification.entity.UserDevice;
+import com.swyp.picke.domain.notification.repository.UserDeviceRepository;
+import com.swyp.picke.domain.user.entity.User;
+import com.swyp.picke.domain.user.repository.UserRepository;
+import com.swyp.picke.global.common.exception.CustomException;
+import com.swyp.picke.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeviceService {
+
+    private final UserDeviceRepository userDeviceRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerDevice(Long userId, RegisterDeviceRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        userDeviceRepository.findByFcmToken(request.fcmToken())
+                .ifPresentOrElse(
+                        device -> device.reassign(user, request.platform()),
+                        () -> userDeviceRepository.save(
+                                UserDevice.builder()
+                                        .user(user)
+                                        .fcmToken(request.fcmToken())
+                                        .platform(request.platform())
+                                        .build()
+                        )
+                );
+    }
+
+    @Transactional
+    public void unregisterDevice(Long userId, String fcmToken) {
+        userDeviceRepository.deleteByUserIdAndFcmToken(userId, fcmToken);
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
@@ -1,8 +1,10 @@
 package com.swyp.picke.domain.notification.service;
 
 import com.swyp.picke.domain.notification.entity.UserDevice;
+import com.swyp.picke.domain.notification.enums.DevicePlatform;
 import com.swyp.picke.domain.notification.enums.NotificationDetailCode;
 import com.swyp.picke.domain.notification.repository.UserDeviceRepository;
+import com.swyp.picke.global.infra.apns.service.ApnsPushService;
 import com.swyp.picke.global.infra.fcm.service.FcmPushService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- * 앱 내 알림(Notification)과 FCM 푸시를 함께 발송하는 알림 정책별 디스패치 서비스.
+ * 앱 내 알림(Notification)과 푸시를 함께 발송하는 알림 정책별 디스패치 서비스.
+ * Android는 FCM, iOS는 APNs로 직접 발송한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ public class NotificationDispatchService {
     private final NotificationService notificationService;
     private final UserDeviceRepository userDeviceRepository;
     private final FcmPushService fcmPushService;
+    private final ApnsPushService apnsPushService;
 
     @Value("${picke.baseUrl}")
     private String baseUrl;
@@ -39,12 +43,12 @@ public class NotificationDispatchService {
 
         String pushTitle = NotificationDetailCode.NEW_BATTLE.getDefaultTitle();
         for (UserDevice device : userDeviceRepository.findAll()) {
-            fcmPushService.send(device, pushTitle, body, data);
+            sendPush(device, pushTitle, body, data);
         }
     }
 
     /**
-     * 내가 작성한 답글에 좋아요가 달렸을 때 답글 작성자에게 인앱 알림 + FCM 푸시를 발송한다.
+     * 내가 작성한 답글에 좋아요가 달렸을 때 답글 작성자에게 인앱 알림 + 푸시를 발송한다.
      */
     public void notifyCommentLike(Long commentAuthorId, Long perspectiveId, Long commentId, String battleTitle) {
         String body = "\"" + battleTitle + "\" 배틀에 남긴 내 답글에 좋아요가 달렸어요.";
@@ -56,7 +60,7 @@ public class NotificationDispatchService {
     }
 
     /**
-     * 내가 작성한 글에 새로운 답글이 달렸을 때 글 작성자에게 인앱 알림 + FCM 푸시를 발송한다.
+     * 내가 작성한 글에 새로운 답글이 달렸을 때 글 작성자에게 인앱 알림 + 푸시를 발송한다.
      */
     public void notifyNewComment(Long perspectiveAuthorId, Long perspectiveId, Long commentId, String battleTitle) {
         String body = "\"" + battleTitle + "\" 배틀에 남긴 내 글에 새로운 답글이 달렸어요.";
@@ -77,7 +81,15 @@ public class NotificationDispatchService {
 
         String pushTitle = detailCode.getDefaultTitle();
         for (UserDevice device : userDeviceRepository.findAllByUserId(userId)) {
-            fcmPushService.send(device, pushTitle, body, data);
+            sendPush(device, pushTitle, body, data);
+        }
+    }
+
+    private void sendPush(UserDevice device, String title, String body, Map<String, String> data) {
+        if (device.getPlatform() == DevicePlatform.IOS) {
+            apnsPushService.send(device, title, body, data);
+        } else {
+            fcmPushService.send(device, title, body, data);
         }
     }
 }

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
@@ -1,0 +1,45 @@
+package com.swyp.picke.domain.notification.service;
+
+import com.swyp.picke.domain.notification.entity.UserDevice;
+import com.swyp.picke.domain.notification.enums.NotificationDetailCode;
+import com.swyp.picke.domain.notification.repository.UserDeviceRepository;
+import com.swyp.picke.global.infra.fcm.service.FcmPushService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 앱 내 알림(Notification)과 FCM 푸시를 함께 발송하는 알림 정책별 디스패치 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class NotificationDispatchService {
+
+    private final NotificationService notificationService;
+    private final UserDeviceRepository userDeviceRepository;
+    private final FcmPushService fcmPushService;
+
+    @Value("${picke.baseUrl}")
+    private String baseUrl;
+
+    /**
+     * 새로운 배틀 발행 시 전체 사용자에게 인앱 broadcast 알림 + FCM 푸시를 발송한다.
+     */
+    public void notifyNewBattle(Long battleId, String battleTitle) {
+        String body = "\"" + battleTitle + "\"에 지금 참여해보세요!";
+
+        notificationService.createBroadcastNotification(NotificationDetailCode.NEW_BATTLE, body, battleId);
+
+        Map<String, String> data = Map.of(
+                "type", "BATTLE",
+                "battleId", String.valueOf(battleId),
+                "url", baseUrl + "/battle/" + battleId
+        );
+
+        String pushTitle = NotificationDetailCode.NEW_BATTLE.getDefaultTitle();
+        for (UserDevice device : userDeviceRepository.findAll()) {
+            fcmPushService.send(device, pushTitle, body, data);
+        }
+    }
+}

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
@@ -42,4 +42,42 @@ public class NotificationDispatchService {
             fcmPushService.send(device, pushTitle, body, data);
         }
     }
+
+    /**
+     * 내가 작성한 답글에 좋아요가 달렸을 때 답글 작성자에게 인앱 알림 + FCM 푸시를 발송한다.
+     */
+    public void notifyCommentLike(Long commentAuthorId, Long perspectiveId, Long commentId) {
+        String body = "내가 남긴 답글에 좋아요가 달렸어요.";
+
+        notificationService.createNotification(
+                commentAuthorId, NotificationDetailCode.COMMENT_LIKE, body, commentId, perspectiveId);
+
+        sendCommentPush(commentAuthorId, NotificationDetailCode.COMMENT_LIKE, body, perspectiveId, commentId);
+    }
+
+    /**
+     * 내가 작성한 글에 새로운 답글이 달렸을 때 글 작성자에게 인앱 알림 + FCM 푸시를 발송한다.
+     */
+    public void notifyNewComment(Long perspectiveAuthorId, Long perspectiveId, Long commentId) {
+        String body = "내가 작성한 글에 새로운 답글이 달렸어요.";
+
+        notificationService.createNotification(
+                perspectiveAuthorId, NotificationDetailCode.NEW_COMMENT, body, commentId, perspectiveId);
+
+        sendCommentPush(perspectiveAuthorId, NotificationDetailCode.NEW_COMMENT, body, perspectiveId, commentId);
+    }
+
+    private void sendCommentPush(Long userId, NotificationDetailCode detailCode, String body, Long perspectiveId, Long commentId) {
+        Map<String, String> data = Map.of(
+                "type", "COMMENT",
+                "perspectiveId", String.valueOf(perspectiveId),
+                "commentId", String.valueOf(commentId),
+                "url", baseUrl + "/perspective/" + perspectiveId + "?commentId=" + commentId
+        );
+
+        String pushTitle = detailCode.getDefaultTitle();
+        for (UserDevice device : userDeviceRepository.findAllByUserId(userId)) {
+            fcmPushService.send(device, pushTitle, body, data);
+        }
+    }
 }

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
@@ -46,8 +46,8 @@ public class NotificationDispatchService {
     /**
      * 내가 작성한 답글에 좋아요가 달렸을 때 답글 작성자에게 인앱 알림 + FCM 푸시를 발송한다.
      */
-    public void notifyCommentLike(Long commentAuthorId, Long perspectiveId, Long commentId) {
-        String body = "내가 남긴 답글에 좋아요가 달렸어요.";
+    public void notifyCommentLike(Long commentAuthorId, Long perspectiveId, Long commentId, String battleTitle) {
+        String body = "\"" + battleTitle + "\" 배틀에 남긴 내 답글에 좋아요가 달렸어요.";
 
         notificationService.createNotification(
                 commentAuthorId, NotificationDetailCode.COMMENT_LIKE, body, commentId, perspectiveId);
@@ -58,8 +58,8 @@ public class NotificationDispatchService {
     /**
      * 내가 작성한 글에 새로운 답글이 달렸을 때 글 작성자에게 인앱 알림 + FCM 푸시를 발송한다.
      */
-    public void notifyNewComment(Long perspectiveAuthorId, Long perspectiveId, Long commentId) {
-        String body = "내가 작성한 글에 새로운 답글이 달렸어요.";
+    public void notifyNewComment(Long perspectiveAuthorId, Long perspectiveId, Long commentId, String battleTitle) {
+        String body = "\"" + battleTitle + "\" 배틀에 남긴 내 글에 새로운 답글이 달렸어요.";
 
         notificationService.createNotification(
                 perspectiveAuthorId, NotificationDetailCode.NEW_COMMENT, body, commentId, perspectiveId);

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationService.java
@@ -36,6 +36,11 @@ public class NotificationService {
 
     @Transactional
     public Notification createNotification(Long userId, NotificationDetailCode detailCode, String body, Long referenceId) {
+        return createNotification(userId, detailCode, body, referenceId, null);
+    }
+
+    @Transactional
+    public Notification createNotification(Long userId, NotificationDetailCode detailCode, String body, Long referenceId, Long perspectiveId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -46,6 +51,7 @@ public class NotificationService {
                 .title(detailCode.getDefaultTitle())
                 .body(body)
                 .referenceId(referenceId)
+                .perspectiveId(perspectiveId)
                 .build();
 
         return notificationRepository.save(notification);
@@ -168,6 +174,7 @@ public class NotificationService {
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getReferenceId(),
+                notification.getPerspectiveId(),
                 isRead,
                 notification.getCreatedAt(),
                 readAt
@@ -182,6 +189,7 @@ public class NotificationService {
                 notification.getTitle(),
                 notification.getBody(),
                 notification.getReferenceId(),
+                notification.getPerspectiveId(),
                 isRead,
                 notification.getCreatedAt()
         );

--- a/src/main/java/com/swyp/picke/domain/perspective/service/CommentLikeService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/CommentLikeService.java
@@ -50,18 +50,19 @@ public class CommentLikeService {
         Long commentId = comment.getId();
         Long commentAuthorId = comment.getUser().getId();
         Long perspectiveId = comment.getPerspective().getId();
+        String battleTitle = comment.getPerspective().getBattle().getTitle();
 
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    notificationDispatchService.notifyCommentLike(commentAuthorId, perspectiveId, commentId);
+                    notificationDispatchService.notifyCommentLike(commentAuthorId, perspectiveId, commentId, battleTitle);
                 }
             });
             return;
         }
 
-        notificationDispatchService.notifyCommentLike(commentAuthorId, perspectiveId, commentId);
+        notificationDispatchService.notifyCommentLike(commentAuthorId, perspectiveId, commentId, battleTitle);
     }
 
     @Transactional

--- a/src/main/java/com/swyp/picke/domain/perspective/service/CommentLikeService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/CommentLikeService.java
@@ -1,5 +1,6 @@
 package com.swyp.picke.domain.perspective.service;
 
+import com.swyp.picke.domain.notification.service.NotificationDispatchService;
 import com.swyp.picke.domain.perspective.dto.response.LikeResponse;
 import com.swyp.picke.domain.perspective.entity.CommentLike;
 import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
@@ -10,6 +11,8 @@ import com.swyp.picke.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class CommentLikeService {
 
     private final PerspectiveCommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final NotificationDispatchService notificationDispatchService;
 
     @Transactional
     public LikeResponse addLike(Long commentId, Long userId) {
@@ -37,7 +41,27 @@ public class CommentLikeService {
                 .build());
         comment.incrementLikeCount();
 
+        notifyCommentLikeAfterCommit(comment);
+
         return new LikeResponse(comment.getId(), comment.getLikeCount(), true);
+    }
+
+    private void notifyCommentLikeAfterCommit(PerspectiveComment comment) {
+        Long commentId = comment.getId();
+        Long commentAuthorId = comment.getUser().getId();
+        Long perspectiveId = comment.getPerspective().getId();
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    notificationDispatchService.notifyCommentLike(commentAuthorId, perspectiveId, commentId);
+                }
+            });
+            return;
+        }
+
+        notificationDispatchService.notifyCommentLike(commentAuthorId, perspectiveId, commentId);
     }
 
     @Transactional

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
@@ -3,6 +3,7 @@ package com.swyp.picke.domain.perspective.service;
 import com.swyp.picke.domain.battle.entity.BattleOption;
 import com.swyp.picke.domain.battle.service.BattleService;
 import com.swyp.picke.domain.battle.util.BattleOptionDisplay;
+import com.swyp.picke.domain.notification.service.NotificationDispatchService;
 import com.swyp.picke.domain.perspective.dto.request.CreateCommentRequest;
 import com.swyp.picke.domain.perspective.dto.request.UpdateCommentRequest;
 import com.swyp.picke.domain.perspective.dto.response.CommentListResponse;
@@ -26,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,6 +48,7 @@ public class PerspectiveCommentService {
     private final BattleVoteService BattleVoteService;
     private final BattleService battleService;
     private final S3PresignedUrlService s3PresignedUrlService;
+    private final NotificationDispatchService notificationDispatchService;
 
     @Transactional
     public CreateCommentResponse createComment(Long perspectiveId, Long userId, CreateCommentRequest request) {
@@ -60,6 +64,8 @@ public class PerspectiveCommentService {
 
         commentRepository.save(comment);
         perspective.incrementCommentCount();
+
+        notifyNewCommentAfterCommit(comment, perspective, userId);
 
         UserSummary userSummary = userQueryService.findSummaryById(userId);
         String characterImageUrl = resolveCharacterImageUrl(userSummary.characterType());
@@ -78,6 +84,28 @@ public class PerspectiveCommentService {
                 true,
                 comment.getCreatedAt()
         );
+    }
+
+    private void notifyNewCommentAfterCommit(PerspectiveComment comment, Perspective perspective, Long commenterId) {
+        Long perspectiveAuthorId = perspective.getUser().getId();
+        if (perspectiveAuthorId.equals(commenterId)) {
+            return;
+        }
+
+        Long commentId = comment.getId();
+        Long perspectiveId = perspective.getId();
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    notificationDispatchService.notifyNewComment(perspectiveAuthorId, perspectiveId, commentId);
+                }
+            });
+            return;
+        }
+
+        notificationDispatchService.notifyNewComment(perspectiveAuthorId, perspectiveId, commentId);
     }
 
     public CommentListResponse getComments(Long perspectiveId, Long userId, String cursor, Integer size) {

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
@@ -94,18 +94,19 @@ public class PerspectiveCommentService {
 
         Long commentId = comment.getId();
         Long perspectiveId = perspective.getId();
+        String battleTitle = perspective.getBattle().getTitle();
 
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    notificationDispatchService.notifyNewComment(perspectiveAuthorId, perspectiveId, commentId);
+                    notificationDispatchService.notifyNewComment(perspectiveAuthorId, perspectiveId, commentId, battleTitle);
                 }
             });
             return;
         }
 
-        notificationDispatchService.notifyNewComment(perspectiveAuthorId, perspectiveId, commentId);
+        notificationDispatchService.notifyNewComment(perspectiveAuthorId, perspectiveId, commentId, battleTitle);
     }
 
     public CommentListResponse getComments(Long perspectiveId, Long userId, String cursor, Integer size) {

--- a/src/main/java/com/swyp/picke/domain/user/service/CreditService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/CreditService.java
@@ -1,5 +1,9 @@
 package com.swyp.picke.domain.user.service;
 
+import com.swyp.picke.domain.battle.entity.Battle;
+import com.swyp.picke.domain.battle.repository.BattleRepository;
+import com.swyp.picke.domain.notification.enums.NotificationDetailCode;
+import com.swyp.picke.domain.notification.service.NotificationService;
 import com.swyp.picke.domain.user.entity.CreditHistory;
 import com.swyp.picke.domain.user.enums.TierCode;
 import com.swyp.picke.domain.user.entity.User;
@@ -23,6 +27,8 @@ public class CreditService {
     private final CreditHistoryRepository creditHistoryRepository;
     private final UserRepository userRepository;
     private final UserService userService;
+    private final NotificationService notificationService;
+    private final BattleRepository battleRepository;
 
     /**
      * 현재 로그인한 유저에게 크레딧 적립 (기본 포인트).
@@ -86,6 +92,12 @@ public class CreditService {
             }
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
+
+        if (amount > 0) {
+            notificationService.createNotification(
+                    userId, NotificationDetailCode.CREDIT_EARNED, buildCreditEarnedMessage(creditType, amount, referenceId), referenceId
+            );
+        }
     }
 
     /**
@@ -115,6 +127,26 @@ public class CreditService {
         if (referenceId == null) {
             throw new CustomException(ErrorCode.CREDIT_REFERENCE_REQUIRED);
         }
+    }
+
+    /**
+     * 적립 타입별 CREDIT_EARNED 인앱 알림 문구 생성.
+     * MAJORITY_WIN은 referenceId(=battleId)로 배틀 제목을 조회해 문구에 포함한다.
+     */
+    private String buildCreditEarnedMessage(CreditType creditType, int amount, Long referenceId) {
+        return switch (creditType) {
+            case DEFAULT_CREDIT -> "픽케에 오신 걸 환영해요! 가입 보너스 +" + amount + "P";
+            case TODAY_CREDIT -> "일일 무료 포인트 +" + amount + " 충전되었어요.";
+            case MAJORITY_WIN -> buildMajorityWinMessage(referenceId, amount);
+            default -> "포인트 +" + amount + "P가 적립되었어요.";
+        };
+    }
+
+    private String buildMajorityWinMessage(Long battleId, int amount) {
+        String title = battleRepository.findById(battleId)
+                .map(Battle::getTitle)
+                .orElse("배틀");
+        return "\"" + title + "\"에서 다수결과 같은 선택을 했어요! +" + amount + "P";
     }
 
     /**

--- a/src/main/java/com/swyp/picke/global/config/ApnsConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/ApnsConfig.java
@@ -1,0 +1,45 @@
+package com.swyp.picke.global.config;
+
+import com.eatthepath.pushy.apns.ApnsClient;
+import com.eatthepath.pushy.apns.ApnsClientBuilder;
+import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+
+/**
+ * 다이렉트 APNs(Apple Push Notification service) 클라이언트 설정.
+ * apns.enabled=true 일 때만 빈을 생성하며, 비활성화 시 ApnsPushService가 발송을 건너뛴다.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "apns", name = "enabled", havingValue = "true")
+public class ApnsConfig {
+
+    @Value("${apns.credentials.location}")
+    private String credentialsLocation;
+
+    @Value("${apns.key-id}")
+    private String keyId;
+
+    @Value("${apns.team-id}")
+    private String teamId;
+
+    @Value("${apns.production}")
+    private boolean production;
+
+    @Bean(destroyMethod = "close")
+    public ApnsClient apnsClient() throws Exception {
+        ApnsSigningKey signingKey = ApnsSigningKey.loadFromPkcs8File(
+                new File(credentialsLocation), teamId, keyId);
+
+        return new ApnsClientBuilder()
+                .setApnsServer(production
+                        ? ApnsClientBuilder.PRODUCTION_APNS_HOST
+                        : ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
+                .setSigningKey(signingKey)
+                .build();
+    }
+}

--- a/src/main/java/com/swyp/picke/global/config/ApnsConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/ApnsConfig.java
@@ -3,22 +3,39 @@ package com.swyp.picke.global.config;
 import com.eatthepath.pushy.apns.ApnsClient;
 import com.eatthepath.pushy.apns.ApnsClientBuilder;
 import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * 다이렉트 APNs(Apple Push Notification service) 클라이언트 설정.
  * apns.enabled=true 일 때만 빈을 생성하며, 비활성화 시 ApnsPushService가 발송을 건너뛴다.
+ * 컨테이너 배포 환경(Railway 등)은 영구 파일시스템이 없으므로,
+ * S3에 업로드해둔 .p8 키(APNS_CREDENTIALS_S3_KEY)를 임시 파일로 받아 사용하고,
+ * 없으면 로컬 개발 환경의 파일 경로(APNS_CREDENTIALS_PATH)를 사용한다.
  */
 @Configuration
 @ConditionalOnProperty(prefix = "apns", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
 public class ApnsConfig {
 
-    @Value("${apns.credentials.location}")
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${apns.credentials.s3-key:}")
+    private String credentialsS3Key;
+
+    @Value("${apns.credentials.location:}")
     private String credentialsLocation;
 
     @Value("${apns.key-id}")
@@ -33,7 +50,7 @@ public class ApnsConfig {
     @Bean(destroyMethod = "close")
     public ApnsClient apnsClient() throws Exception {
         ApnsSigningKey signingKey = ApnsSigningKey.loadFromPkcs8File(
-                new File(credentialsLocation), teamId, keyId);
+                resolveCredentialsFile(), teamId, keyId);
 
         return new ApnsClientBuilder()
                 .setApnsServer(production
@@ -41,5 +58,20 @@ public class ApnsConfig {
                         : ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
                 .setSigningKey(signingKey)
                 .build();
+    }
+
+    private File resolveCredentialsFile() throws Exception {
+        if (!credentialsS3Key.isBlank()) {
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(credentialsS3Key)
+                    .build();
+
+            Path tempFile = Files.createTempFile("apns-key", ".p8");
+            tempFile.toFile().deleteOnExit();
+            s3Client.getObject(request, tempFile);
+            return tempFile.toFile();
+        }
+        return new File(credentialsLocation);
     }
 }

--- a/src/main/java/com/swyp/picke/global/config/FirebaseConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/FirebaseConfig.java
@@ -1,0 +1,32 @@
+package com.swyp.picke.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.credentials.location}")
+    private String credentialsLocation;
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(new FileInputStream(credentialsLocation)))
+                .build();
+
+        FirebaseApp firebaseApp = FirebaseApp.getApps().isEmpty()
+                ? FirebaseApp.initializeApp(options)
+                : FirebaseApp.getInstance();
+
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/src/main/java/com/swyp/picke/global/config/FirebaseConfig.java
+++ b/src/main/java/com/swyp/picke/global/config/FirebaseConfig.java
@@ -4,23 +4,41 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
+/**
+ * 컨테이너 배포 환경(Railway 등)은 영구 파일시스템이 없으므로,
+ * S3에 업로드해둔 서비스 계정 JSON(FCM_CREDENTIALS_S3_KEY)을 우선 사용하고,
+ * 없으면 로컬 개발 환경의 파일 경로(FCM_CREDENTIALS_PATH)를 사용한다.
+ */
 @Configuration
+@RequiredArgsConstructor
 public class FirebaseConfig {
 
-    @Value("${firebase.credentials.location}")
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${firebase.credentials.s3-key:}")
+    private String credentialsS3Key;
+
+    @Value("${firebase.credentials.location:}")
     private String credentialsLocation;
 
     @Bean
     public FirebaseMessaging firebaseMessaging() throws IOException {
         FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(new FileInputStream(credentialsLocation)))
+                .setCredentials(GoogleCredentials.fromStream(loadCredentials()))
                 .build();
 
         FirebaseApp firebaseApp = FirebaseApp.getApps().isEmpty()
@@ -28,5 +46,16 @@ public class FirebaseConfig {
                 : FirebaseApp.getInstance();
 
         return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+    private InputStream loadCredentials() throws IOException {
+        if (!credentialsS3Key.isBlank()) {
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(credentialsS3Key)
+                    .build();
+            return s3Client.getObject(request);
+        }
+        return new FileInputStream(credentialsLocation);
     }
 }

--- a/src/main/java/com/swyp/picke/global/infra/apns/service/ApnsPushService.java
+++ b/src/main/java/com/swyp/picke/global/infra/apns/service/ApnsPushService.java
@@ -1,0 +1,75 @@
+package com.swyp.picke.global.infra.apns.service;
+
+import com.eatthepath.pushy.apns.ApnsClient;
+import com.eatthepath.pushy.apns.PushNotificationResponse;
+import com.eatthepath.pushy.apns.util.ApnsPayloadBuilder;
+import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
+import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
+import com.eatthepath.pushy.apns.util.TokenUtil;
+import com.swyp.picke.domain.notification.entity.UserDevice;
+import com.swyp.picke.domain.notification.repository.UserDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * iOS 디바이스에 FCM을 거치지 않고 APNs로 직접 푸시를 발송한다.
+ * apns.enabled=false(미설정)인 환경에서는 ApnsClient 빈이 없으므로 발송을 건너뛴다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApnsPushService {
+
+    private static final Set<String> INVALID_TOKEN_REASONS = Set.of(
+            "BadDeviceToken", "Unregistered", "DeviceTokenNotForTopic");
+
+    private final Optional<ApnsClient> apnsClient;
+    private final UserDeviceRepository userDeviceRepository;
+
+    @Value("${apns.bundle-id}")
+    private String bundleId;
+
+    public void send(UserDevice device, String title, String body, Map<String, String> data) {
+        if (apnsClient.isEmpty()) {
+            log.warn("APNs가 설정되지 않아 푸시를 건너뜁니다. deviceId={}", device.getId());
+            return;
+        }
+
+        ApnsPayloadBuilder payloadBuilder = new SimpleApnsPayloadBuilder()
+                .setAlertTitle(title)
+                .setAlertBody(body)
+                .setSound("default");
+        data.forEach(payloadBuilder::addCustomProperty);
+
+        String token = TokenUtil.sanitizeTokenString(device.getFcmToken());
+        SimpleApnsPushNotification notification =
+                new SimpleApnsPushNotification(token, bundleId, payloadBuilder.build());
+
+        apnsClient.get().sendNotification(notification).whenComplete((response, cause) -> {
+            if (cause != null) {
+                log.warn("APNs 푸시 전송 실패. deviceId={}, error={}", device.getId(), cause.getMessage());
+                return;
+            }
+            handleResponse(device, response);
+        });
+    }
+
+    private void handleResponse(UserDevice device, PushNotificationResponse<SimpleApnsPushNotification> response) {
+        if (response.isAccepted()) {
+            return;
+        }
+
+        String reason = response.getRejectionReason().orElse("UNKNOWN");
+        log.warn("APNs 푸시 거부됨. deviceId={}, reason={}", device.getId(), reason);
+
+        if (INVALID_TOKEN_REASONS.contains(reason)) {
+            userDeviceRepository.deleteById(device.getId());
+        }
+    }
+}

--- a/src/main/java/com/swyp/picke/global/infra/fcm/service/FcmPushService.java
+++ b/src/main/java/com/swyp/picke/global/infra/fcm/service/FcmPushService.java
@@ -1,14 +1,10 @@
 package com.swyp.picke.global.infra.fcm.service;
 
 import com.google.firebase.messaging.AndroidConfig;
-import com.google.firebase.messaging.ApnsConfig;
-import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import com.swyp.picke.domain.notification.entity.UserDevice;
-import com.swyp.picke.domain.notification.enums.DevicePlatform;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,45 +19,22 @@ public class FcmPushService {
     private final FirebaseMessaging firebaseMessaging;
 
     /**
-     * 디바이스 플랫폼에 맞는 FCM 메시지를 구성해 발송한다.
-     * Android는 data-only 페이로드로, iOS는 notification + data(url 포함)로 분기한다.
+     * Android 디바이스에 FCM data-only 메시지를 발송한다.
+     * iOS는 FCM을 거치지 않고 ApnsPushService가 APNs로 직접 발송한다.
      */
     public void send(UserDevice device, String title, String body, Map<String, String> data) {
-        Message message = device.getPlatform() == DevicePlatform.IOS
-                ? buildIosMessage(device.getFcmToken(), title, body, data)
-                : buildAndroidMessage(device.getFcmToken(), data);
-
-        try {
-            firebaseMessaging.send(message);
-        } catch (FirebaseMessagingException e) {
-            log.warn("FCM 푸시 전송 실패. token={}, platform={}, error={}",
-                    device.getFcmToken(), device.getPlatform(), e.getMessage());
-        }
-    }
-
-    private Message buildAndroidMessage(String token, Map<String, String> data) {
-        return Message.builder()
-                .setToken(token)
+        Message message = Message.builder()
+                .setToken(device.getFcmToken())
                 .putAllData(data)
                 .setAndroidConfig(AndroidConfig.builder()
                         .setPriority(AndroidConfig.Priority.HIGH)
                         .build())
                 .build();
-    }
 
-    private Message buildIosMessage(String token, String title, String body, Map<String, String> data) {
-        return Message.builder()
-                .setToken(token)
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
-                .putAllData(data)
-                .setApnsConfig(ApnsConfig.builder()
-                        .setAps(Aps.builder()
-                                .setSound("default")
-                                .build())
-                        .build())
-                .build();
+        try {
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            log.warn("FCM 푸시 전송 실패. deviceId={}, error={}", device.getId(), e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/swyp/picke/global/infra/fcm/service/FcmPushService.java
+++ b/src/main/java/com/swyp/picke/global/infra/fcm/service/FcmPushService.java
@@ -1,0 +1,67 @@
+package com.swyp.picke.global.infra.fcm.service;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.swyp.picke.domain.notification.entity.UserDevice;
+import com.swyp.picke.domain.notification.enums.DevicePlatform;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmPushService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    /**
+     * 디바이스 플랫폼에 맞는 FCM 메시지를 구성해 발송한다.
+     * Android는 data-only 페이로드로, iOS는 notification + data(url 포함)로 분기한다.
+     */
+    public void send(UserDevice device, String title, String body, Map<String, String> data) {
+        Message message = device.getPlatform() == DevicePlatform.IOS
+                ? buildIosMessage(device.getFcmToken(), title, body, data)
+                : buildAndroidMessage(device.getFcmToken(), data);
+
+        try {
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            log.warn("FCM 푸시 전송 실패. token={}, platform={}, error={}",
+                    device.getFcmToken(), device.getPlatform(), e.getMessage());
+        }
+    }
+
+    private Message buildAndroidMessage(String token, Map<String, String> data) {
+        return Message.builder()
+                .setToken(token)
+                .putAllData(data)
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(AndroidConfig.Priority.HIGH)
+                        .build())
+                .build();
+    }
+
+    private Message buildIosMessage(String token, String title, String body, Map<String, String> data) {
+        return Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putAllData(data)
+                .setApnsConfig(ApnsConfig.builder()
+                        .setAps(Aps.builder()
+                                .setSound("default")
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,11 @@ spring:
       credentials:
         location: ${GCP_CREDENTIALS_PATH}
 
+# 3-1. Firebase Admin SDK (FCM 푸시 알림)
+firebase:
+  credentials:
+    location: ${FCM_CREDENTIALS_PATH}
+
 # 4. 인증 및 보안 설정 (OAuth2, JWT)
 oauth:
   kakao:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,10 +41,20 @@ spring:
       credentials:
         location: ${GCP_CREDENTIALS_PATH}
 
-# 3-1. Firebase Admin SDK (FCM 푸시 알림)
+# 3-1. Firebase Admin SDK (FCM 푸시 알림 - Android)
 firebase:
   credentials:
     location: ${FCM_CREDENTIALS_PATH}
+
+# 3-2. APNs (다이렉트 APNs 푸시 알림 - iOS)
+apns:
+  enabled: ${APNS_ENABLED:false}
+  credentials:
+    location: ${APNS_CREDENTIALS_PATH:}
+  key-id: ${APNS_KEY_ID:}
+  team-id: ${APNS_TEAM_ID:${APPLE_TEAM_ID:}}
+  bundle-id: ${APNS_BUNDLE_ID:}
+  production: ${APNS_PRODUCTION:false}
 
 # 4. 인증 및 보안 설정 (OAuth2, JWT)
 oauth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,13 +44,15 @@ spring:
 # 3-1. Firebase Admin SDK (FCM 푸시 알림 - Android)
 firebase:
   credentials:
-    location: ${FCM_CREDENTIALS_PATH}
+    location: ${FCM_CREDENTIALS_PATH:}
+    s3-key: ${FCM_CREDENTIALS_S3_KEY:}
 
 # 3-2. APNs (다이렉트 APNs 푸시 알림 - iOS)
 apns:
   enabled: ${APNS_ENABLED:false}
   credentials:
     location: ${APNS_CREDENTIALS_PATH:}
+    s3-key: ${APNS_CREDENTIALS_S3_KEY:}
   key-id: ${APNS_KEY_ID:}
   team-id: ${APNS_TEAM_ID:${APPLE_TEAM_ID:}}
   bundle-id: ${APNS_BUNDLE_ID:}


### PR DESCRIPTION
  ## #️⃣연관된 이슈
  - #262
  
  ## 📝 작업 내용

  ### ✨ Feat                                                           
  | 내용 | 파일 |
  |------|------|
  | 디바이스 푸시 토큰 등록/해제 API 추가 (Android: FCM 토큰, iOS: APNs 디바이스 토큰) | `DeviceController.java`, `DeviceService.java`, `RegisterDeviceRequest.java`,
  `UserDevice.java`, `DevicePlatform.java`, `UserDeviceRepository.java` |                                                                                    
  | FCM(Android) 푸시 발송 인프라 구축 (Firebase Admin SDK) | `FirebaseConfig.java`, `FcmPushService.java`, `build.gradle` |
  | iOS 푸시를 FCM 경유 방식에서 다이렉트 APNs 발송으로 전환 (Pushy) | `ApnsConfig.java`, `ApnsPushService.java`, `FcmPushService.java`, `NotificationDispatchService.java`,        
  `build.gradle` |
  | 새 배틀 발행 시 인앱 알림 + 푸시 발송 | `BattleServiceImpl.java`, `NotificationDispatchService.java` |
  | 답글 좋아요 / 새 댓글 발생 시 인앱 알림 + 푸시 발송 | `CommentLikeService.java`, `PerspectiveCommentService.java`, `NotificationDispatchService.java` |
  | 포인트 적립 시 인앱 알림 발송 | `CreditService.java` |
  | 알림 API 명세 문서 작성 | `docs/api-specs/notification-api.md` |

  ### ♻️ Refactor
  | 내용 | 파일 |
  |------|------|
  | 답글 좋아요/새 댓글 알림 문구에 배틀 제목 포함하도록 개선 | `NotificationDispatchService.java`, `CommentLikeService.java`, `PerspectiveCommentService.java` |

  ### 🐛 Fix
  | 내용 | 파일 |
  |------|------|
  | 컨테이너 배포 환경(Railway)에서 FCM/APNs 자격증명 파일(JSON/.p8)을 읽지 못해 서버 기동 자체가 실패하던 문제 수정 — S3에서 자격증명을 다운로드해 사용하도록 변경 (로컬은 기존    
  파일 경로 방식 그대로 폴백) | `FirebaseConfig.java`, `ApnsConfig.java`, `application.yml` |

  ## 📌 공유 사항
  > 1. **(중요) Railway dev Variables 추가 완료** — 이 PR이 배포되려면 아래 값이 필요하며, dev 환경엔 이미 세팅해뒀습니다.
  >    - `FCM_CREDENTIALS_S3_KEY`, `APNS_CREDENTIALS_S3_KEY` (S3 `pique-bucket/credentials/`에 Firebase 서비스 계정 JSON, APNs `.p8` 키 업로드 완료)
  >    - `APNS_ENABLED=true`, `APNS_KEY_ID`, `APNS_BUNDLE_ID`, `APNS_PRODUCTION`
  >    - `APNS_TEAM_ID`는 따로 안 넣어도 기존 `APPLE_TEAM_ID`로 폴백됩니다.
  > 2. **운영(main) 배포 시에도 동일하게 Railway 변수 추가 + S3 파일 업로드가 필요**합니다.
  > 3. iOS는 더 이상 FCM을 거치지 않고 서버가 APNs로 직접 발송합니다. 디바이스 등록 시 `fcmToken` 필드에 iOS는 APNs 디바이스 토큰(hex 문자열)을 보내야 합니다. 자세한 내용은        
  `docs/api-specs/notification-api.md` 참고.
  > 4. 새 의존성 추가: `firebase-admin:9.9.0`, `com.eatthepath:pushy:0.15.4`

  ## ✅ 체크리스트
  - [x] Reviewer에 팀원들을 선택했나요?
  - [x] Assignees에 본인을 선택했나요?
  - [x] 컨벤션에 맞는 Type을 선택했나요?
  - [x] Development에 이슈를 연동했나요?
  - [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [x] 컨벤션을 지키고 있나요?
  - [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [x] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷
  <!-- Swagger/Postman으로 디바이스 등록, 알림함 조회, 푸시 수신 테스트 캡처 첨부 -->

  ## 💬 리뷰 요구사항
  > 1. APNs 환경(sandbox/production)이 `APNS_PRODUCTION` 전역 설정 1개로 고정되는 구조인데, 개발(TestFlight)/운영(App Store) 빌드를 동시에 지원하려면 별도 설계가 필요해 보입니다 — 
  의견 부탁드립니다.
  > 2. FCM/APNs 자격증명을 S3에서 받아오는 방식(이번 Fix)이 적절한지, 다른 방식을 선호하시면 의견 부탁드립니다.