### PR TITLE
#264 [Fix] AdMob SSV 포인트 미적립 버그 수정

### DIFF
--- a/src/main/java/com/swyp/picke/domain/reward/service/AdMobRewardServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/reward/service/AdMobRewardServiceImpl.java
@@ -30,46 +30,42 @@ public class AdMobRewardServiceImpl implements AdMobRewardService {
     @Override
     @Transactional
     public String processReward(AdMobRewardRequest request) {
+        log.info("[AdMob] SSV 처리 시작: transaction_id={}, userTag={}, reward_amount={}, ad_unit={}",
+                request.transaction_id(), request.getUserTag(), request.reward_amount(), request.ad_unit());
+
         // 1. 서명 검증 (공식 파라미터 기반)
         /*if (!verifyAdMobSignature(request)) {
-            log.warn("AdMob 서명 검증 실패: transaction_id={}", request.transaction_id());
+            log.warn("[AdMob] 서명 검증 실패: transaction_id={}", request.transaction_id());
             throw new CustomException(ErrorCode.REWARD_INVALID_SIGNATURE);
         }*/
 
         // 2. 중복 처리 방지
         if (adRewardHistoryRepository.existsByTransactionId(request.transaction_id())) {
-            log.info("이미 처리된 광고 요청입니다: transaction_id={}", request.transaction_id());
+            log.info("[AdMob] 이미 처리된 요청: transaction_id={}", request.transaction_id());
             return "Already Processed";
         }
 
-        // 3. 유저 확인 (UserTag를 이용해 UserService에서 실제 유저 확보)
-        // request.getUserTag()는 custom_data 혹은 user_id를 반환합니다.
+        // 3. 유저 확인 (custom_data → user_id 순으로 조회)
+        log.info("[AdMob] 유저 조회 시도: userTag={}", request.getUserTag());
         User user = userService.findByUserTag(request.getUserTag());
+        log.info("[AdMob] 유저 확인 완료: userId={}", user.getId());
 
-        // 4. 보상 이력(AdRewardHistory) 저장
+        // 4. 보상 이력 저장 후 즉시 id 확보 (saveAndFlush)
         AdRewardHistory history = AdRewardHistory.builder()
                 .transactionId(request.transaction_id())
                 .user(user)
                 .rewardAmount(request.reward_amount())
-                .rewardItem(request.getRewardType()) // // Enum 명칭 저장
+                .rewardItem(request.getRewardType())
                 .build();
-        adRewardHistoryRepository.save(history);
+        adRewardHistoryRepository.saveAndFlush(history);
+        log.info("[AdMob] 보상 이력 저장 완료: historyId={}", history.getId());
 
-        // // 5. 크레딧 적립
-        Long refId = parseTransactionId(request.transaction_id());
-        creditService.addCredit(user.getId(), CreditType.FREE_CHARGE, request.reward_amount(), refId);
+        // 5. 크레딧 적립 (history.getId()를 referenceId로 사용해 unique 충돌 방지)
+        creditService.addCredit(user.getId(), CreditType.FREE_CHARGE, request.reward_amount(), history.getId());
+        log.info("[AdMob] 포인트 적립 완료: userId={}, amount={}, historyId={}",
+                user.getId(), request.reward_amount(), history.getId());
 
-        log.info("보상 지급 완료: userTag={}, userId={}, amount={}",
-                 user.getUserTag(), user.getId(), request.reward_amount());
         return "OK";
-    }
-
-    private Long parseTransactionId(String transactionId) {
-        try {
-            return Long.parseLong(transactionId.replaceAll("[^0-9]", ""));
-        } catch (Exception e) {
-            return (long) Math.abs(transactionId.hashCode());
-        }
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #264

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| `parseTransactionId()` 제거 및 `history.getId()`를 referenceId로 사용 | `AdMobRewardServiceImpl.java` |
| `save()` → `saveAndFlush()`로 변경해 저장 즉시 id 확보 | `AdMobRewardServiceImpl.java` |
| 처리 단계별 `[AdMob]` 로그 추가 | `AdMobRewardServiceImpl.java` |

## 📌 공유 사항
> 1. **버그 원인**: `parseTransactionId()`가 Google SSV `transaction_id`를 숫자 추출 후 `Long` 변환하는 방식이었는데, 변환 실패 시 `hashCode()` 폴백 사용. `credit_histories` 테이블의 `(user_id, credit_type, reference_id)` unique 제약으로 인해 hashCode 충돌 시 포인트 적립이 조용히 무시됨.
> 2. **수정 방향**: `AdRewardHistory` 저장 후 auto-generated `id`를 `referenceId`로 사용해 충돌 원천 차단.
> 3. **로그 추가**: 개발/운영 서버 양쪽에서 SSV 콜백 처리 흐름 추적 가능하도록 단계별 로그 추가.

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
<!-- Swagger, Postman 테스트 결과 첨부 부탁드립니다 -->

## 💬 리뷰 요구사항
> 1. `saveAndFlush()` 후 `history.getId()`가 항상 non-null임을 가정하고 있는데, IDENTITY 전략에서 문제 없는지 확인 부탁드립니다.