### PR TITLE
#262 merge

### DIFF
--- a/src/main/java/com/swyp/picke/domain/admin/service/AdminNotificationService.java
+++ b/src/main/java/com/swyp/picke/domain/admin/service/AdminNotificationService.java
@@ -8,6 +8,7 @@ import com.swyp.picke.domain.notification.entity.Notification;
 import com.swyp.picke.domain.notification.enums.NotificationCategory;
 import com.swyp.picke.domain.notification.enums.NotificationDetailCode;
 import com.swyp.picke.domain.notification.repository.NotificationRepository;
+import com.swyp.picke.domain.notification.service.NotificationDispatchService;
 import com.swyp.picke.domain.notification.service.NotificationService;
 import com.swyp.picke.global.common.exception.CustomException;
 import com.swyp.picke.global.common.exception.ErrorCode;
@@ -25,6 +26,7 @@ public class AdminNotificationService {
     private static final int DEFAULT_PAGE_SIZE = 20;
 
     private final NotificationService notificationService;
+    private final NotificationDispatchService notificationDispatchService;
     private final NotificationRepository notificationRepository;
 
     @Transactional
@@ -36,6 +38,12 @@ public class AdminNotificationService {
                 request.body(),
                 null
         );
+
+        if (detailCode.getCategory() == NotificationCategory.NOTICE
+                || detailCode.getCategory() == NotificationCategory.EVENT) {
+            notificationDispatchService.notifyAdminNotice(detailCode, request.title(), request.body());
+        }
+
         return toDetailResponse(notification);
     }
 

--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -219,6 +219,7 @@ public class BattleServiceImpl implements BattleService {
         List<Battle> candidates = battleRepository.findAutoAssignableTodayPicks(today, PageRequest.of(0, missingCount));
         for (Battle candidate : candidates) {
             candidate.updateTargetDate(today);
+            notifyNewBattleAfterCommit(candidate);
         }
     }
 

--- a/src/main/java/com/swyp/picke/domain/notification/repository/UserDeviceRepository.java
+++ b/src/main/java/com/swyp/picke/domain/notification/repository/UserDeviceRepository.java
@@ -13,6 +13,8 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     List<UserDevice> findAllByUserId(Long userId);
 
+    List<UserDevice> findAllByUserIdIn(List<Long> userIds);
+
     List<UserDevice> findAllByUserIdAndPlatform(Long userId, DevicePlatform platform);
 
     void deleteByUserIdAndFcmToken(Long userId, String fcmToken);

--- a/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
+++ b/src/main/java/com/swyp/picke/domain/notification/service/NotificationDispatchService.java
@@ -4,9 +4,13 @@ import com.swyp.picke.domain.notification.entity.UserDevice;
 import com.swyp.picke.domain.notification.enums.DevicePlatform;
 import com.swyp.picke.domain.notification.enums.NotificationDetailCode;
 import com.swyp.picke.domain.notification.repository.UserDeviceRepository;
+import com.swyp.picke.domain.user.entity.UserSettings;
+import com.swyp.picke.domain.user.repository.UserSettingsRepository;
 import com.swyp.picke.global.infra.apns.service.ApnsPushService;
 import com.swyp.picke.global.infra.fcm.service.FcmPushService;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service;
 /**
  * 앱 내 알림(Notification)과 푸시를 함께 발송하는 알림 정책별 디스패치 서비스.
  * Android는 FCM, iOS는 APNs로 직접 발송한다.
+ * 인앱 알림은 항상 생성되며, 푸시 발송 여부만 {@link UserSettings}의 알림 ON/OFF 설정을 따른다.
  */
 @Service
 @RequiredArgsConstructor
@@ -21,6 +26,7 @@ public class NotificationDispatchService {
 
     private final NotificationService notificationService;
     private final UserDeviceRepository userDeviceRepository;
+    private final UserSettingsRepository userSettingsRepository;
     private final FcmPushService fcmPushService;
     private final ApnsPushService apnsPushService;
 
@@ -42,7 +48,8 @@ public class NotificationDispatchService {
         );
 
         String pushTitle = NotificationDetailCode.NEW_BATTLE.getDefaultTitle();
-        for (UserDevice device : userDeviceRepository.findAll()) {
+        List<Long> userIds = userSettingsRepository.findUserIdsByNewBattleEnabledTrue();
+        for (UserDevice device : userDeviceRepository.findAllByUserIdIn(userIds)) {
             sendPush(device, pushTitle, body, data);
         }
     }
@@ -56,7 +63,9 @@ public class NotificationDispatchService {
         notificationService.createNotification(
                 commentAuthorId, NotificationDetailCode.COMMENT_LIKE, body, commentId, perspectiveId);
 
-        sendCommentPush(commentAuthorId, NotificationDetailCode.COMMENT_LIKE, body, perspectiveId, commentId);
+        if (isPushEnabled(commentAuthorId, UserSettings::isContentLikeEnabled)) {
+            sendCommentPush(commentAuthorId, NotificationDetailCode.COMMENT_LIKE, body, perspectiveId, commentId);
+        }
     }
 
     /**
@@ -68,7 +77,30 @@ public class NotificationDispatchService {
         notificationService.createNotification(
                 perspectiveAuthorId, NotificationDetailCode.NEW_COMMENT, body, commentId, perspectiveId);
 
-        sendCommentPush(perspectiveAuthorId, NotificationDetailCode.NEW_COMMENT, body, perspectiveId, commentId);
+        if (isPushEnabled(perspectiveAuthorId, UserSettings::isNewCommentEnabled)) {
+            sendCommentPush(perspectiveAuthorId, NotificationDetailCode.NEW_COMMENT, body, perspectiveId, commentId);
+        }
+    }
+
+    /**
+     * 관리자가 등록한 공지/이벤트 알림에 대해 '이벤트 및 소식 알림' 설정이 ON인 사용자에게 푸시를 발송한다.
+     */
+    public void notifyAdminNotice(NotificationDetailCode detailCode, String title, String body) {
+        Map<String, String> data = Map.of("type", detailCode.getCategory().name());
+
+        List<Long> userIds = userSettingsRepository.findUserIdsByMarketingEventEnabledTrue();
+        for (UserDevice device : userDeviceRepository.findAllByUserIdIn(userIds)) {
+            sendPush(device, title, body, data);
+        }
+    }
+
+    /**
+     * 유저의 알림 ON/OFF 설정을 확인한다. 설정이 없는 경우(레거시 유저 등) 기본값은 true.
+     */
+    private boolean isPushEnabled(Long userId, Predicate<UserSettings> condition) {
+        return userSettingsRepository.findByUserId(userId)
+                .map(condition::test)
+                .orElse(true);
     }
 
     private void sendCommentPush(Long userId, NotificationDetailCode detailCode, String body, Long perspectiveId, Long commentId) {

--- a/src/main/java/com/swyp/picke/domain/perspective/repository/CommentLikeRepository.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/repository/CommentLikeRepository.java
@@ -4,6 +4,7 @@ import com.swyp.picke.domain.perspective.entity.CommentLike;
 import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
@@ -11,4 +12,8 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     boolean existsByCommentAndUserId(PerspectiveComment comment, Long userId);
 
     Optional<CommentLike> findByCommentAndUserId(PerspectiveComment comment, Long userId);
+
+    void deleteAllByCommentIn(List<PerspectiveComment> comments);
+
+    void deleteAllByComment(PerspectiveComment comment);
 }

--- a/src/main/java/com/swyp/picke/domain/perspective/repository/CommentReportRepository.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/repository/CommentReportRepository.java
@@ -4,9 +4,15 @@ import com.swyp.picke.domain.perspective.entity.CommentReport;
 import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
     boolean existsByCommentAndUserId(PerspectiveComment comment, Long userId);
 
     long countByComment(PerspectiveComment comment);
+
+    void deleteAllByCommentIn(List<PerspectiveComment> comments);
+
+    void deleteAllByComment(PerspectiveComment comment);
 }

--- a/src/main/java/com/swyp/picke/domain/perspective/repository/PerspectiveCommentRepository.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/repository/PerspectiveCommentRepository.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public interface PerspectiveCommentRepository extends JpaRepository<PerspectiveComment, Long> {
 
+    List<PerspectiveComment> findByPerspective(Perspective perspective);
+
     List<PerspectiveComment> findByPerspectiveOrderByCreatedAtDesc(Perspective perspective, Pageable pageable);
 
     List<PerspectiveComment> findByPerspectiveAndCreatedAtBeforeOrderByCreatedAtDesc(Perspective perspective, LocalDateTime cursor, Pageable pageable);

--- a/src/main/java/com/swyp/picke/domain/perspective/repository/PerspectiveLikeRepository.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/repository/PerspectiveLikeRepository.java
@@ -22,4 +22,6 @@ public interface PerspectiveLikeRepository extends JpaRepository<PerspectiveLike
     List<PerspectiveLike> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
 
     long countByUserId(Long userId);
+
+    void deleteAllByPerspective(Perspective perspective);
 }

--- a/src/main/java/com/swyp/picke/domain/perspective/repository/PerspectiveReportRepository.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/repository/PerspectiveReportRepository.java
@@ -9,4 +9,6 @@ public interface PerspectiveReportRepository extends JpaRepository<PerspectiveRe
     boolean existsByPerspectiveAndUserId(Perspective perspective, Long userId);
 
     long countByPerspective(Perspective perspective);
+
+    void deleteAllByPerspective(Perspective perspective);
 }

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveCommentService.java
@@ -12,6 +12,7 @@ import com.swyp.picke.domain.perspective.dto.response.UpdateCommentResponse;
 import com.swyp.picke.domain.perspective.entity.Perspective;
 import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
 import com.swyp.picke.domain.perspective.repository.CommentLikeRepository;
+import com.swyp.picke.domain.perspective.repository.CommentReportRepository;
 import com.swyp.picke.domain.perspective.repository.PerspectiveCommentRepository;
 import com.swyp.picke.domain.perspective.repository.PerspectiveRepository;
 import com.swyp.picke.domain.user.dto.response.UserSummary;
@@ -44,6 +45,7 @@ public class PerspectiveCommentService {
     private final PerspectiveCommentRepository commentRepository;
     private final UserRepository userRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final CommentReportRepository commentReportRepository;
     private final UserService userQueryService;
     private final BattleVoteService BattleVoteService;
     private final BattleService battleService;
@@ -203,6 +205,8 @@ public class PerspectiveCommentService {
         PerspectiveComment comment = findCommentById(commentId);
         validateOwnership(comment, userId);
 
+        commentLikeRepository.deleteAllByComment(comment);
+        commentReportRepository.deleteAllByComment(comment);
         commentRepository.delete(comment);
         perspective.decrementCommentCount();
     }

--- a/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
+++ b/src/main/java/com/swyp/picke/domain/perspective/service/PerspectiveService.java
@@ -15,8 +15,12 @@ import com.swyp.picke.domain.perspective.dto.response.PerspectiveDetailResponse;
 import com.swyp.picke.domain.perspective.dto.response.PerspectiveListResponse;
 import com.swyp.picke.domain.perspective.dto.response.UpdatePerspectiveResponse;
 import com.swyp.picke.domain.perspective.entity.Perspective;
+import com.swyp.picke.domain.perspective.entity.PerspectiveComment;
+import com.swyp.picke.domain.perspective.repository.CommentLikeRepository;
+import com.swyp.picke.domain.perspective.repository.CommentReportRepository;
 import com.swyp.picke.domain.perspective.repository.PerspectiveCommentRepository;
 import com.swyp.picke.domain.perspective.repository.PerspectiveLikeRepository;
+import com.swyp.picke.domain.perspective.repository.PerspectiveReportRepository;
 import com.swyp.picke.domain.perspective.repository.PerspectiveRepository;
 import com.swyp.picke.domain.user.dto.response.UserSummary;
 import com.swyp.picke.domain.user.enums.CharacterType;
@@ -43,6 +47,9 @@ public class PerspectiveService {
     private final PerspectiveRepository perspectiveRepository;
     private final PerspectiveCommentRepository perspectiveCommentRepository;
     private final PerspectiveLikeRepository perspectiveLikeRepository;
+    private final PerspectiveReportRepository perspectiveReportRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentReportRepository commentReportRepository;
     private final BattleService battleService;
     private final BattleVoteService BattleVoteService;
     private final UserService userQueryService;
@@ -152,7 +159,16 @@ public class PerspectiveService {
     public void deletePerspective(Long perspectiveId, Long userId) {
         Perspective perspective = findPerspectiveById(perspectiveId);
         validateOwnership(perspective, userId);
+
+        List<PerspectiveComment> comments = perspectiveCommentRepository.findByPerspective(perspective);
+        if (!comments.isEmpty()) {
+            commentLikeRepository.deleteAllByCommentIn(comments);
+            commentReportRepository.deleteAllByCommentIn(comments);
+        }
         perspectiveCommentRepository.deleteAllByPerspective(perspective);
+
+        perspectiveLikeRepository.deleteAllByPerspective(perspective);
+        perspectiveReportRepository.deleteAllByPerspective(perspective);
         perspectiveRepository.delete(perspective);
     }
 

--- a/src/main/java/com/swyp/picke/domain/user/repository/UserSettingsRepository.java
+++ b/src/main/java/com/swyp/picke/domain/user/repository/UserSettingsRepository.java
@@ -1,10 +1,18 @@
 package com.swyp.picke.domain.user.repository;
 
 import com.swyp.picke.domain.user.entity.UserSettings;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserSettingsRepository extends JpaRepository<UserSettings, Long> {
 
     Optional<UserSettings> findByUserId(Long userId);
+
+    @Query("SELECT s.user.id FROM UserSettings s WHERE s.newBattleEnabled = true")
+    List<Long> findUserIdsByNewBattleEnabledTrue();
+
+    @Query("SELECT s.user.id FROM UserSettings s WHERE s.marketingEventEnabled = true")
+    List<Long> findUserIdsByMarketingEventEnabledTrue();
 }


### PR DESCRIPTION
  ## #️ 연관된 이슈
  - #262

  ## 📝 작업 내용

  ### ✨  Feat
  | 내용 | 파일 |
  |------|------|
  | 새 배틀/답글 좋아요/새 댓글/관리자 공지·이벤트 알림 발송 시 UserSettings의 ON/OFF 설정을 확인해 OFF인 사용자에게는 푸시를 보내지 않도록 분기 (인앱 알림은 항상 생성) | `NotificationDispatchService.java`,
  `UserSettingsRepository.java`, `UserDeviceRepository.java`, `AdminNotificationService.java` |
  | 오늘의 픽으로 자동 배정된 배틀에도 새 배틀 알림(인앱+푸시) 발송 추가 | `BattleServiceImpl.java` |

  ### 🐛 Fix
  | 내용 | 파일 |
  |------|------|
  | 관점/댓글 삭제 시 좋아요·신고 잔여 데이터가 남아 FK 제약 조건 위반 오류가 발생하던 문제 수정 | `PerspectiveService.java`, `PerspectiveCommentService.java`, `CommentLikeRepository.java`,
  `CommentReportRepository.java`, `PerspectiveCommentRepository.java`, `PerspectiveLikeRepository.java`, `PerspectiveReportRepository.java` |

  ## 📌 공유 사항
  > 1. 알림 ON/OFF 설정 매핑은 다음과 같습니다.
  >    - `newBattleEnabled` → 새 배틀 알림
  >    - `contentLikeEnabled` → 좋아요 알림
  >    - `newCommentEnabled` → 새 댓글 알림
  >    - `marketingEventEnabled` → 이벤트 및 소식 알림 (공지/이벤트)
  >    - `commentReplyEnabled`, `battleResultEnabled` → 현재 매핑되는 알림 이벤트가 없어 보류 (정책 미정)
  > 2. OFF 상태여도 인앱 Notification은 항상 생성되고, 푸시 발송만 차단됩니다. UserSettings가 없는 레거시 유저는 기본값 ON으로 처리됩니다.

  ## ✅  체크리스트
  - [x] Reviewer에 팀원들을 선택했나요?
  - [x] Assignees에 본인을 선택했나요?
  - [x] 컨벤션에 맞는 Type을 선택했나요?
  - [x] Development에 이슈를 연동했나요?
  - [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
  - [x] 컨벤션을 지키고 있나요?
  - [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
  - [x] 팀원들에게 PR 링크 공유를 했나요?

  ## 📸 스크린샷


  ## 💬 리뷰 요구사항
  > 1. 관리자 공지/이벤트 알림(POLICY_CHANGE/PROMOTION)을 `marketingEventEnabled` 하나로 묶어서 게이팅했는데, 이 매핑이 적절한지 의견 부탁드립니다.