### PR TITLE
#277 [Fix] AdMob SSV 콜백 URL 검증 요청 처리 실패

### DIFF
--- a/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
+++ b/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
@@ -31,9 +31,9 @@ public class AdMobRewardController {
             AdMobRewardRequest request) {
         log.info("AdMob SSV 콜백 수신: transaction_id={}", request.transaction_id());
 
-        // AdMob 콘솔 URL 검증 요청 (파라미터 없는 빈 요청) 시 200 반환
-        if (request.transaction_id() == null || request.signature() == null) {
-            log.info("AdMob URL 검증 요청 수신 (파라미터 없음) - 200 반환");
+        // 실제 SSV 콜백에는 key_id가 반드시 포함됨 — key_id 없으면 AdMob 콘솔 URL 검증 요청으로 판별
+        if (request.transaction_id() == null || request.signature() == null || request.key_id() == null) {
+            log.info("AdMob URL 검증 요청 수신 - 200 반환");
             return ApiResponse.onSuccess(AdMobRewardResponse.from("OK"));
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #277

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| AdMob URL 검증 요청 조기 반환 조건에 `key_id == null` 추가 | `AdMobRewardController.java` |

## 📌 공유 사항
> 1. AdMob 콘솔에서 SSV URL 등록 시 '확인' 버튼을 누르면 구글이 더미 파라미터(`transaction_id=123456789`, `ad_unit=1234567890` 등)를 포함한 테스트 요청을 보냄
> 2. 실제 SSV 콜백에는 `key_id`가 반드시 포함되므로, `key_id == null` 조건 추가로 URL 검증 요청을 안전하게 판별 가능

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
<!-- AdMob 콘솔 URL 검증 성공 화면 첨부 예정 -->

## 💬 리뷰 요구사항
> 1. `key_id` null 여부로 AdMob URL 검증 요청을 판별하는 방식이 적절한지 확인 부탁드립니다.