### PR TITLE
#279 [Fix] AdMob SSV 엔드포인트 검증 실패 시 항상 200 반환

### DIFF
--- a/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
+++ b/src/main/java/com/swyp/picke/domain/reward/controller/AdMobRewardController.java
@@ -31,13 +31,18 @@ public class AdMobRewardController {
             AdMobRewardRequest request) {
         log.info("AdMob SSV 콜백 수신: transaction_id={}", request.transaction_id());
 
-        // 실제 SSV 콜백에는 key_id가 반드시 포함됨 — key_id 없으면 AdMob 콘솔 URL 검증 요청으로 판별
+        // AdMob SSV 스펙: 검증 실패 포함 모든 경우에 200 반환 (비정상 응답 시 구글이 재시도)
         if (request.transaction_id() == null || request.signature() == null || request.key_id() == null) {
             log.info("AdMob URL 검증 요청 수신 - 200 반환");
             return ApiResponse.onSuccess(AdMobRewardResponse.from("OK"));
         }
 
-        String status = rewardService.processReward(request);
-        return ApiResponse.onSuccess(AdMobRewardResponse.from(status));
+        try {
+            String status = rewardService.processReward(request);
+            return ApiResponse.onSuccess(AdMobRewardResponse.from(status));
+        } catch (Exception e) {
+            log.warn("[AdMob] 처리 실패 - 보상 미지급 후 200 반환: transaction_id={}, reason={}", request.transaction_id(), e.getMessage());
+            return ApiResponse.onSuccess(AdMobRewardResponse.from("OK"));
+        }
     }
 }

--- a/src/main/java/com/swyp/picke/domain/reward/service/AdMobRewardServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/reward/service/AdMobRewardServiceImpl.java
@@ -38,13 +38,13 @@ public class AdMobRewardServiceImpl implements AdMobRewardService {
         // 1. ad_unit 유효성 검사
         if (!adMobConfig.getAllowedUnitIds().contains(request.ad_unit())) {
             log.warn("[AdMob] 허용되지 않은 ad_unit: {}", request.ad_unit());
-            throw new CustomException(ErrorCode.REWARD_INVALID_SIGNATURE);
+            return "OK";
         }
 
         // 2. 서명 검증 (공식 파라미터 기반)
         if (!verifyAdMobSignature(request)) {
             log.warn("[AdMob] 서명 검증 실패: transaction_id={}", request.transaction_id());
-            throw new CustomException(ErrorCode.REWARD_INVALID_SIGNATURE);
+            return "OK";
         }
 
         // 3. 중복 처리 방지


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #279

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| 검증 실패 시 예외 대신 200 반환 (try-catch 추가) | `AdMobRewardController.java` |
| ad_unit·서명 검증 실패 시 예외 대신 조기 return 처리 | `AdMobRewardServiceImpl.java` |

## 📌 공유 사항
> 1. AdMob SSV 스펙상 콜백 엔드포인트는 검증 실패 포함 모든 경우에 HTTP 200을 반환해야 합니다. 200이 아닌 응답을 받으면 구글이 콜백을 재시도합니다.
> 2. URL 콘솔 검증 요청(`transaction_id=123456789`, `ad_unit=1234567890` 등 더미값)도 key_id를 포함해 보내기 때문에 기존 조기 반환 조건만으로는 처리 불가했습니다.
> 3. 검증 실패 시 보상은 지급하지 않고 로그만 남긴 뒤 200을 반환합니다.

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷

## 💬 리뷰 요구사항
> 1. 검증 실패 시 항상 200을 반환하는 방식이 AdMob SSV 스펙에 맞게 적용됐는지 확인 부탁드립니다.