### PR TITLE
#283 [Fix] /me/content-activities voteSide null 반환 버그

### DIFF
--- a/src/main/resources/db/migration/V20260619_01__backfill_battle_option_display_order.sql
+++ b/src/main/resources/db/migration/V20260619_01__backfill_battle_option_display_order.sql
@@ -1,0 +1,12 @@
+-- display_order가 NULL인 battle_options 백필: 같은 battle_id 내 id 오름차순으로 1, 2 배정
+UPDATE battle_options bo
+SET display_order = sub.row_num
+FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY battle_id ORDER BY id) AS row_num
+    FROM battle_options
+    WHERE display_order IS NULL
+) sub
+WHERE bo.id = sub.id;
+
+ALTER TABLE battle_options ALTER COLUMN display_order SET NOT NULL;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #283

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| display_order NULL 데이터 백필 및 NOT NULL 제약 추가 | `V20260619_01__backfill_battle_option_display_order.sql` |

## 📌 공유 사항
> 1. `V20260410` 마이그레이션에서 `battle_options.display_order` 컬럼이 NOT NULL 없이 추가되어 기존 레코드가 NULL 상태였음.
> 2. 백필 기준: 같은 `battle_id` 내에서 `id` 오름차순으로 1, 2 배정 (PRO/CON 순서).
> 3. 백필 완료 후 NOT NULL 제약 추가.

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?

## 💬 리뷰 요구사항
> 1. 백필 SQL 로직 검토 부탁드립니다.