### PR TITLE
#285 [Feat] content-activities 응답에 option_title 필드 추가

### DIFF
--- a/docs/api-specs/user-api.md
+++ b/docs/api-specs/user-api.md
@@ -227,7 +227,8 @@
           "nickname": "사색하는고양이",
           "character_type": "CAT"
         },
-        "stance": "반대",
+        "vote_side": "CON",
+        "option_title": "반대합니다",
         "content": "제도가 무서운 건, 사회적 압력이 선택을 의무로 바꿀 수 있다는 거예요.",
         "like_count": 1340,
         "created_at": "2026-03-08T12:00:00"

--- a/src/main/java/com/swyp/picke/domain/user/dto/response/ContentActivityListResponse.java
+++ b/src/main/java/com/swyp/picke/domain/user/dto/response/ContentActivityListResponse.java
@@ -21,6 +21,7 @@ public record ContentActivityListResponse(
             String battleTitle,
             AuthorInfo author,
             VoteSide voteSide,
+            String optionTitle,
             String content,
             int likeCount,
             LocalDateTime createdAt

--- a/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
+++ b/src/main/java/com/swyp/picke/domain/user/service/MypageService.java
@@ -252,6 +252,7 @@ public class MypageService {
         );
 
         VoteSide voteSide = BattleOptionDisplay.voteSide(option);
+        String optionTitle = BattleOptionDisplay.opinion(option);
 
         return new ContentActivityListResponse.ContentActivityItem(
                 activityId, activityType,
@@ -260,6 +261,7 @@ public class MypageService {
                 battle != null ? battle.getTitle() : null,
                 authorInfo,
                 voteSide,
+                optionTitle,
                 content,
                 perspective.getLikeCount(),
                 createdAt


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #285

## 📝 작업 내용

### ✨ Feat
| 내용 | 파일 |
|------|------|
| `ContentActivityItem`에 `option_title` 필드 추가 | `ContentActivityListResponse.java` |
| `toActivityItem()`에서 `BattleOptionDisplay.opinion(option)`으로 `optionTitle` 세팅 | `MypageService.java` |

### 📄 Docs
| 내용 | 파일 |
|------|------|
| `content-activities` 응답 예시에 `vote_side`, `option_title` 필드 반영 | `user-api.md` |

## 📌 공유 사항
> 1. 기존 `vote_side` (PRO/CON) 필드는 클라이언트 호환성을 위해 유지하고, 실제 배틀 옵션 텍스트를 담는 `option_title` 필드를 추가했습니다.

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷

## 💬 리뷰 요구사항
> 1.