### PR TITLE
#287 [Fix] AdMob SSV 서명 검증 오류로 인한 포인트 미지급 버그

### DIFF
--- a/src/main/java/com/swyp/picke/domain/reward/service/AdMobRewardServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/reward/service/AdMobRewardServiceImpl.java
@@ -82,9 +82,9 @@ public class AdMobRewardServiceImpl implements AdMobRewardService {
      */
     private boolean verifyAdMobSignature(AdMobRewardRequest request) {
         try {
-            // // 조립 시 signature와 key_id는 제외하고 나머지 8개 파라미터를 조립합니다.
-            // // 순서: ad_network -> ad_unit -> custom_data -> reward_amount -> reward_item -> timestamp -> transaction_id -> user_id
-            StringBuilder sb = new StringBuilder();
+            // RewardedAdsVerifier.verify()는 내부에서 URI.getQuery()를 사용하므로 scheme을 포함한 완전한 URL이어야 함
+            // key_id와 signature는 반드시 마지막 두 파라미터 순서로 위치해야 함 (Tink 라이브러리 스펙)
+            StringBuilder sb = new StringBuilder("https://admob.google.com/reward?");
             if (request.ad_network() != null) sb.append("ad_network=").append(request.ad_network()).append("&");
             sb.append("ad_unit=").append(request.ad_unit()).append("&");
             if (request.custom_data() != null) sb.append("custom_data=").append(request.custom_data()).append("&");
@@ -93,11 +93,12 @@ public class AdMobRewardServiceImpl implements AdMobRewardService {
             sb.append("timestamp=").append(request.timestamp()).append("&");
             sb.append("transaction_id=").append(request.transaction_id());
             if (request.user_id() != null) sb.append("&user_id=").append(request.user_id());
+            sb.append("&key_id=").append(request.key_id());
+            sb.append("&signature=").append(request.signature());
 
-            String fullQueryString = sb.toString();
+            String fullUrl = sb.toString();
 
-            // // Tink 라이브러리를 통해 signature와 key_id를 사용하여 검증
-            rewardedAdsVerifier.verify(fullQueryString);
+            rewardedAdsVerifier.verify(fullUrl);
             return true;
         } catch (GeneralSecurityException e) {
             log.error("보상 서명 보안 에러: {}", e.getMessage());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #287

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| AdMob SSV 서명 검증 시 전체 URL 형태로 조립하도록 수정 | `AdMobRewardServiceImpl.java` |

## 📌 공유 사항
> 1. `RewardedAdsVerifier.verify(String)`은 내부에서 `new URI(input).getQuery()`를 호출하는 구조입니다.
> 2. 기존 코드는 query string만 넘겨 `getQuery()`가 null을 반환 → NPE → 서명 검증 항상 실패 → 포인트 미지급이 발생했습니다.
> 3. Tink 라이브러리 바이트코드 분석으로 `key_id`와 `signature`가 반드시 마지막 두 파라미터 순서여야 한다는 스펙도 확인하여 함께 반영했습니다.

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?

## 📸 스크린샷
> 컴파일 오류 없음 (`./gradlew compileJava` 통과)

## 💬 리뷰 요구사항
> 1. Tink `RewardedAdsVerifier.verify()`에 넘기는 URL의 host(`admob.google.com`)는 라이브러리가 파싱 시 무시하므로 임의 값이어도 동작하나, 실제 AdMob 콜백 URL과 동일하게 맞추는 것이 좋을지 의견 부탁드립니다.