### PR TITLE
#289 [Fix] 오늘의 배틀 개수 변경

### DIFF
--- a/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/battle/service/BattleServiceImpl.java
@@ -199,11 +199,11 @@ public class BattleServiceImpl implements BattleService {
     @Transactional
     public TodayBattleListResponse getTodayBattles() {
         LocalDate today = LocalDate.now();
-        ensureTodayPicks(today, 3);
+        ensureTodayPicks(today, 1);
         List<Battle> battles = battleRepository.findByTargetDateAndStatusAndDeletedAtIsNull(today, BattleStatus.PUBLISHED);
 
         List<Battle> limitedBattles = battles.stream()
-                .limit(3)
+                .limit(1)
                 .collect(Collectors.toList());
 
         List<TodayBattleResponse> items = convertToTodayResponses(limitedBattles);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #289

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| 오늘의 배틀 노출 개수를 3개에서 1개로 변경 (자동 채움 개수도 동일하게 조정) | `BattleServiceImpl.java` |

## 📌 공유 사항
> 1. 안드로이드 팀 보고 건 - 빠른 배틀이 하루 1개만 설정되어야 하는데 백엔드가 3개를 그대로 내려주고 있었음. 안드로이드 측도 1개만 노출하도록 별도 수정 예정.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?

## 💬 리뷰 요구사항
> 1. 오늘의 배틀 개수를 상수화(설정값)하는 것이 나을지, 하드코딩 유지가 괜찮을지 의견 부탁드립니다.