### PR TITLE
#293 [Fix] 사전투표 철학자 아이콘 미노출

### DIFF
--- a/docs/api-specs/home-api.md
+++ b/docs/api-specs/home-api.md
@@ -48,6 +48,7 @@
 - `options[]`
   - `label`
   - `title`
+  - `imageUrl` (철학자 아이콘 이미지 URL, 미등록 시 `null`)
 
 ---
 

--- a/docs/api-specs/poll-api.md
+++ b/docs/api-specs/poll-api.md
@@ -28,6 +28,7 @@
   - `options[]`
     - `label` (`A`, `B`, ...)
     - `title`
+    - `imageUrl` (철학자 아이콘 이미지 경로)
 
 ### 2.2 Poll 목록
 - `GET /api/v1/admin/polls`

--- a/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollOptionRequest.java
+++ b/src/main/java/com/swyp/picke/domain/admin/dto/poll/request/AdminPollOptionRequest.java
@@ -5,7 +5,8 @@ import com.swyp.picke.domain.poll.enums.PollOptionLabel;
 public record AdminPollOptionRequest(
         PollOptionLabel label,
         String title,
-        Integer displayOrder
+        Integer displayOrder,
+        String imageUrl
 ) {}
 
 

--- a/src/main/java/com/swyp/picke/domain/home/dto/response/HomeTodayVoteOptionResponse.java
+++ b/src/main/java/com/swyp/picke/domain/home/dto/response/HomeTodayVoteOptionResponse.java
@@ -4,5 +4,6 @@ import com.swyp.picke.domain.battle.enums.BattleOptionLabel;
 
 public record HomeTodayVoteOptionResponse(
         BattleOptionLabel label,
-        String title
+        String title,
+        String imageUrl
 ) {}

--- a/src/main/java/com/swyp/picke/domain/home/service/HomeService.java
+++ b/src/main/java/com/swyp/picke/domain/home/service/HomeService.java
@@ -21,7 +21,9 @@ import com.swyp.picke.domain.quiz.entity.Quiz;
 import com.swyp.picke.domain.quiz.entity.QuizOption;
 import com.swyp.picke.domain.quiz.enums.QuizOptionLabel;
 import com.swyp.picke.domain.quiz.service.QuizService;
+import com.swyp.picke.global.infra.s3.enums.FileCategory;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
+import com.swyp.picke.global.infra.s3.util.ResourceUrlProvider;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -44,6 +46,7 @@ public class HomeService {
     private final PollService pollService;
     private final NotificationService notificationService;
     private final S3PresignedUrlService s3PresignedUrlService;
+    private final ResourceUrlProvider urlProvider;
 
     public HomeResponse getHome(Long userId) {
         boolean newNotice = false;
@@ -139,7 +142,8 @@ public class HomeService {
                         .thenComparing(option -> option.getId() == null ? Long.MAX_VALUE : option.getId()))
                 .map(option -> new HomeTodayVoteOptionResponse(
                         BattleOptionLabel.valueOf(option.getLabel().name()),
-                        option.getTitle()
+                        option.getTitle(),
+                        urlProvider.getImageUrl(FileCategory.PHILOSOPHER, option.getImageUrl())
                 ))
                 .toList();
 

--- a/src/main/java/com/swyp/picke/domain/poll/converter/PollConverter.java
+++ b/src/main/java/com/swyp/picke/domain/poll/converter/PollConverter.java
@@ -8,13 +8,19 @@ import com.swyp.picke.domain.poll.dto.response.PollOptionResponse;
 import com.swyp.picke.domain.poll.dto.response.PollSimpleResponse;
 import com.swyp.picke.domain.poll.entity.Poll;
 import com.swyp.picke.domain.poll.entity.PollOption;
+import com.swyp.picke.global.infra.s3.enums.FileCategory;
+import com.swyp.picke.global.infra.s3.util.ResourceUrlProvider;
 import java.util.Comparator;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class PollConverter {
+
+    private final ResourceUrlProvider urlProvider;
 
     private static final Comparator<PollOption> OPTION_SORTER =
             Comparator.comparing((PollOption option) -> option.getDisplayOrder() == null ? Integer.MAX_VALUE : option.getDisplayOrder())
@@ -83,7 +89,8 @@ public class PollConverter {
                         option.getLabel(),
                         option.getTitle(),
                         option.getDisplayOrder(),
-                        option.getVoteCount()
+                        option.getVoteCount(),
+                        urlProvider.getImageUrl(FileCategory.PHILOSOPHER, option.getImageUrl())
                 ))
                 .toList();
     }

--- a/src/main/java/com/swyp/picke/domain/poll/dto/response/PollOptionResponse.java
+++ b/src/main/java/com/swyp/picke/domain/poll/dto/response/PollOptionResponse.java
@@ -7,7 +7,8 @@ public record PollOptionResponse(
         PollOptionLabel label,
         String title,
         Integer displayOrder,
-        Long voteCount
+        Long voteCount,
+        String imageUrl
 ) {
 }
 

--- a/src/main/java/com/swyp/picke/domain/poll/entity/PollOption.java
+++ b/src/main/java/com/swyp/picke/domain/poll/entity/PollOption.java
@@ -38,19 +38,24 @@ public class PollOption extends BaseEntity {
     @Column(name = "vote_count", nullable = false)
     private Long voteCount;
 
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
     @Builder
-    public PollOption(Poll poll, PollOptionLabel label, String title, Integer displayOrder, Long voteCount) {
+    public PollOption(Poll poll, PollOptionLabel label, String title, Integer displayOrder, Long voteCount, String imageUrl) {
         this.poll = poll;
         this.label = label;
         this.title = title;
         this.displayOrder = displayOrder;
         this.voteCount = voteCount == null ? 0L : voteCount;
+        this.imageUrl = imageUrl;
     }
 
 
-    public void update(String title, Integer displayOrder) {
+    public void update(String title, Integer displayOrder, String imageUrl) {
         if (title != null) this.title = title;
         if (displayOrder != null) this.displayOrder = displayOrder;
+        if (imageUrl != null) this.imageUrl = imageUrl;
     }
 
     public void increaseVoteCount() {

--- a/src/main/java/com/swyp/picke/domain/poll/service/PollServiceImpl.java
+++ b/src/main/java/com/swyp/picke/domain/poll/service/PollServiceImpl.java
@@ -127,6 +127,7 @@ public class PollServiceImpl implements PollService {
                         .label(optionRequest.label())
                         .title(optionRequest.title())
                         .displayOrder(displayOrder)
+                        .imageUrl(optionRequest.imageUrl())
                         .build();
                 option = pollOptionRepository.save(option);
                 savedOptions.add(option);
@@ -169,10 +170,11 @@ public class PollServiceImpl implements PollService {
                             .label(optionRequest.label())
                             .title(optionRequest.title())
                             .displayOrder(displayOrder)
+                            .imageUrl(optionRequest.imageUrl())
                             .build();
                     option = pollOptionRepository.save(option);
                 } else {
-                    option.update(optionRequest.title(), displayOrder);
+                    option.update(optionRequest.title(), displayOrder, optionRequest.imageUrl());
                 }
             }
 

--- a/src/main/resources/db/migration/V20260705_02__add_image_url_to_poll_options.sql
+++ b/src/main/resources/db/migration/V20260705_02__add_image_url_to_poll_options.sql
@@ -1,0 +1,3 @@
+-- Add image_url column to poll_options so pre-vote (사전투표) options can show a philosopher icon,
+-- matching the existing battle_options.image_url column.
+ALTER TABLE poll_options ADD COLUMN IF NOT EXISTS image_url VARCHAR(500);

--- a/src/test/java/com/swyp/picke/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/swyp/picke/domain/home/service/HomeServiceTest.java
@@ -19,6 +19,7 @@ import com.swyp.picke.domain.quiz.enums.QuizOptionLabel;
 import com.swyp.picke.domain.quiz.enums.QuizStatus;
 import com.swyp.picke.domain.quiz.service.QuizService;
 import com.swyp.picke.global.infra.s3.service.S3PresignedUrlService;
+import com.swyp.picke.global.infra.s3.util.ResourceUrlProvider;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +50,9 @@ class HomeServiceTest {
 
     @Mock
     private S3PresignedUrlService s3PresignedUrlService;
+
+    @Mock
+    private ResourceUrlProvider urlProvider;
 
     @InjectMocks
     private HomeService homeService;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #293

## 📝 작업 내용

### 🐛 Fix
| 내용 | 파일 |
|------|------|
| poll_options 테이블에 image_url 컬럼 추가 | `V20260705_02__add_image_url_to_poll_options.sql` |
| PollOption 엔티티에 imageUrl 필드 추가 | `PollOption.java` |
| 관리자 사전투표 옵션 생성/수정 요청에 imageUrl 추가 | `AdminPollOptionRequest.java` |
| 옵션 생성/수정 시 imageUrl 반영 | `PollServiceImpl.java` |
| 사전투표 상세 응답에 imageUrl 추가 (리소스 URL 변환) | `PollOptionResponse.java`, `PollConverter.java` |
| 홈 "사전투표" 응답에 철학자 이미지 URL 매핑 추가 | `HomeTodayVoteOptionResponse.java`, `HomeService.java` |
| 테스트에 ResourceUrlProvider 목 추가 | `HomeServiceTest.java` |
| API 명세서 갱신 | `poll-api.md`, `home-api.md` |

## 📌 공유 사항
> 1. 배틀(BattleOption.imageUrl)과 동일하게 FileCategory.PHILOSOPHER 경로로 이미지 URL을 변환합니다.
> 2. 기존 사전투표 옵션들은 image_url이 비어있으므로, 관리자 패널에서 철학자 아이콘 이미지를 등록해야 실제로 노출됩니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 팀원들에게 PR 링크 공유를 했나요?